### PR TITLE
Person or institution as contributor, allow predefined list

### DIFF
--- a/forms/details-expression.xml
+++ b/forms/details-expression.xml
@@ -50,6 +50,7 @@
         <xi:include href="includes/element_buttons.xbl" parse="xml"/>
         <xi:include href="includes/id.xbl" parse="xml"/>
         <xi:include href="includes/relator.xbl" parse="xml"/>
+        <xi:include href="includes/person_list.xbl" parse="xml"/>
         
     </h:head>
     

--- a/forms/details-item.xml
+++ b/forms/details-item.xml
@@ -45,7 +45,8 @@
         <xi:include href="includes/id.xbl" parse="xml"/>
         <xi:include href="includes/item-input.xbl" parse="xml"/>
         <xi:include href="includes/linked_sources.xbl" parse="xml"/>
-        <xi:include href="includes/relator.xbl" parse="xml"/>
+        <xi:include href="includes/relator.xbl" parse="xml"/>        
+        <xi:include href="includes/person_list.xbl" parse="xml"/>
         <xi:include href="includes/rism_sigla_select.xbl" parse="xml"/>
     </h:head>
     
@@ -87,7 +88,7 @@
                 
                 <xf:group ref="instance('data-instance')//m:item[@xml:id=instance('temp')/id]">
                     <h:span class="blocklabel strong">Item 
-                        <h:a class="help">&#160;?<h:span class="comment">At item level, 
+                        <h:a class="help">&#1p60;?<h:span class="comment">At item level, 
                             information specific to an individual copy of a source should be entered. <h:br/>
                             Information common to all copies of this source should be given at source level.<h:br/>
                             Manuscripts are somewhat special, being sources having only one item. Manuscripts, too, 

--- a/forms/details-item.xml
+++ b/forms/details-item.xml
@@ -88,7 +88,7 @@
                 
                 <xf:group ref="instance('data-instance')//m:item[@xml:id=instance('temp')/id]">
                     <h:span class="blocklabel strong">Item 
-                        <h:a class="help">&#1p60;?<h:span class="comment">At item level, 
+                        <h:a class="help">&#160;?<h:span class="comment">At item level, 
                             information specific to an individual copy of a source should be entered. <h:br/>
                             Information common to all copies of this source should be given at source level.<h:br/>
                             Manuscripts are somewhat special, being sources having only one item. Manuscripts, too, 

--- a/forms/details-performance.xml
+++ b/forms/details-performance.xml
@@ -50,6 +50,7 @@
         <xi:include href="includes/element_buttons_typed.xbl" parse="xml"/>
         <xi:include href="includes/id.xbl" parse="xml"/>
         <xi:include href="includes/relator.xbl" parse="xml"/>
+        <xi:include href="includes/person_list.xbl" parse="xml"/>
         
     </h:head>
     

--- a/forms/details-performance.xml
+++ b/forms/details-performance.xml
@@ -128,7 +128,7 @@
                             
                             <h:div class="persname-box">
                                 <h:div class="vertical_spacer"/>
-                                <h:div class="blocklabel strong">Persons</h:div>
+                                <h:div class="blocklabel strong">Contributors</h:div>
                                 <xi:include href="includes/person-input.xml"/>
                             </h:div>
                             <h:br clear="all"/>

--- a/forms/details-reference.xml
+++ b/forms/details-reference.xml
@@ -50,6 +50,8 @@
         <xi:include href="includes/element_buttons_typed.xbl" parse="xml"/>
         <xi:include href="includes/id.xbl" parse="xml"/>
         <xi:include href="includes/rism_sigla_select.xbl" parse="xml"/>
+        <xi:include href="includes/person_list.xbl" parse="xml"/>
+        
         
     </h:head>
     

--- a/forms/details-source.xml
+++ b/forms/details-source.xml
@@ -43,6 +43,7 @@
         <xi:include href="includes/item-input.xbl" parse="xml"/>
         <xi:include href="includes/linked_sources.xbl" parse="xml"/>
         <xi:include href="includes/relator.xbl" parse="xml"/>
+        <xi:include href="includes/person_list.xbl" parse="xml"/>
         <xi:include href="includes/rism_sigla_select.xbl" parse="xml"/>
         <xi:include href="includes/source-input.xbl" parse="xml"/>
     </h:head>

--- a/forms/edit-form-head.xml
+++ b/forms/edit-form-head.xml
@@ -371,6 +371,7 @@
   <xi:include href="includes/linked_sources.xbl" parse="xml"/>
   <xi:include href="includes/performance_list.xbl" parse="xml"/>
   <xi:include href="includes/relator.xbl" parse="xml"/>
+  <xi:include href="includes/person_list.xbl" parse="xml"/>
   <xi:include href="includes/source_list.xbl" parse="xml"/>  
   <xi:include href="includes/rism_sigla_select.xbl" parse="xml"/>
   

--- a/forms/includes/item-input.xbl
+++ b/forms/includes/item-input.xbl
@@ -372,6 +372,9 @@
                     <h:span class="blocklabel">List of hands
                     <dcm:attribute-editor ref="."/>                                                    
                     </h:span>
+                    <dcm:create nodeset="m:hand"
+                      label="Add list of hands"
+                      origin="xxf:instance('empty-instance')/m:meiHead/m:manifestationList/m:manifestation/m:itemList/m:item/m:physDesc/m:handList/m:hand"/>
                     <xf:repeat nodeset="m:hand" id="repeat-source-physdesc-handlist" class="nowrap">
                         <xi:include href="hand-input.xml" parse="xml"/>
                     </xf:repeat>

--- a/forms/includes/item-input.xbl
+++ b/forms/includes/item-input.xbl
@@ -364,9 +364,6 @@
                 </h:div>
                 
                 <h:div>
-                  <dcm:create nodeset="m:handList"
-                              label="Add list of hands"
-                              origin="xxf:instance('empty-instance')/m:meiHead/m:manifestationList/m:manifestation/m:itemList/m:item/m:physDesc/m:handList"/>
                   <xf:group ref="m:handList">
                     <h:hr/>
                     <h:span class="blocklabel">List of hands

--- a/forms/includes/item.xbl
+++ b/forms/includes/item.xbl
@@ -370,7 +370,7 @@
                   <dcm:create nodeset="m:handList"
                               label="Add list of hands"
                               origin="xxf:instance('empty-instance')/m:meiHead/m:manifestationList/m:manifestation/m:itemList/m:item/m:physDesc/m:handList"/>
-                  <xf:group ref="m:handList">
+                  <xf:group ref="m:handList">                  
                     <h:hr/>
                     <h:span class="blocklabel">List of hands
                     <dcm:attribute-editor ref="."/>                                                    

--- a/forms/includes/person-input.xml
+++ b/forms/includes/person-input.xml
@@ -37,14 +37,14 @@
         <xi:include href="certainty-input.xml" parse="xml"/>
         <dcm:authority/>
         <!-- a more generic condition would have been nice but didn't work here -->
-        <xf:group ref=".[name(..)!='hand']">
+        <xf:group ref=".[name(.)!='hand']">
             <dcm:element-buttons 
                 triggers="add remove up down" 
                 nodeset="m:persName" 
                 index="relators-repeat"
                 origin="xxf:instance('empty-instance')/m:meiHead/m:workList/m:work/m:contributor/m:persName[1]"/>
         </xf:group>
-        <xf:group ref=".[name(..)='hand']">
+        <xf:group ref=".[name(.)='hand']">
             <dcm:element-buttons 
                 triggers="remove" 
                 nodeset="m:persName" 
@@ -55,13 +55,13 @@
         <h:br/>
     </xf:repeat>
 
-    <xf:group ref=".[name(.)='contributor']">
-        <dcm:create ref=".[not(m:corpName)]"
-            nodeset="m:corpName"
+    <xf:group ref=".[name(.) = ('contributor', 'event') or name(..) = 'titleStmt']">
+        <dcm:create ref=".[not(m:corpName[@role != 'ensemble'])]"
+            nodeset="m:corpName[@role != 'ensemble']"
             label="Add institution"
-            origin="xxf:instance('empty-instance')/m:meiHead/m:workList/m:work/m:contributor/m:corpName"/>
+            origin="xxf:instance('empty-instance')/m:meiHead/m:workList/m:work/m:contributor/m:corpName[1]"/>
 
-        <xf:group ref="m:corpName">
+        <xf:group ref="m:corpName[@role!='ensemble']">
             <h:div class="blocklabel strong">Institutions</h:div>
             <h:div class="blocklabel">
                 <h:span class="fixed_width_mediumlong">Name</h:span>
@@ -80,7 +80,7 @@
             </h:div>
         </xf:group>
 
-        <xf:repeat nodeset="m:corpName" id="corp-relators-repeat">
+        <xf:repeat nodeset="m:corpName[@role!='ensemble']" id="corp-relators-repeat">
             <dcm:relator/>
             <xi:include href="certainty-input.xml" parse="xml"/>
             <dcm:authority/>

--- a/forms/includes/person-input.xml
+++ b/forms/includes/person-input.xml
@@ -12,9 +12,9 @@
         nodeset="m:persName"
         label="Add person"
         origin="xxf:instance('empty-instance')/m:meiHead/m:workList/m:work/m:contributor/m:persName"/>
- 
     
     <xf:group ref="m:persName">
+        <h:div class="blocklabel strong">Persons</h:div>
         <h:div class="blocklabel">
             <h:span class="fixed_width_mediumlong">Name</h:span>
             <h:span class="fixed_width"></h:span>
@@ -32,7 +32,6 @@
         </h:div>
     </xf:group>
     
-
     <xf:repeat nodeset="m:persName" id="relators-repeat">
         <dcm:relator/>
         <xi:include href="certainty-input.xml" parse="xml"/>
@@ -55,5 +54,44 @@
         <dcm:attribute-editor ref="."/>
         <h:br/>
     </xf:repeat>
-        
+
+    <xf:group ref=".[name(.)='contributor']">
+        <dcm:create ref=".[not(m:corpName)]"
+            nodeset="m:corpName"
+            label="Add institution"
+            origin="xxf:instance('empty-instance')/m:meiHead/m:workList/m:work/m:contributor/m:corpName"/>
+
+        <xf:group ref="m:corpName">
+            <h:div class="blocklabel strong">Institutions</h:div>
+            <h:div class="blocklabel">
+                <h:span class="fixed_width_mediumlong">Name</h:span>
+                <h:span class="fixed_width"></h:span>
+                <h:span class="fixed_width_mediumlong"> Relation <h:a class="help">&#160;?<h:span class="comment">Specifies the person's relation to the item, e.g. "Composer"
+                    or "Author". The list is based on MARC relators as defined at http://id.loc.gov/vocabulary/relators</h:span></h:a>
+                </h:span>
+                <h:span class="fixed_width">
+                    Certainty <h:a class="help">&#160;?<h:span class="comment">Indicates the degree of certainty of the person's identity</h:span></h:a>
+                </h:span>
+                <!--<xf:group ref="..[m:persName[@auth or @auth.uri or @codedval]]">-->
+                    <h:span class="fixed_width_long"> Authority file <h:a class="help">&#160;?<h:span class="comment">References to
+                        authority files are used for disambiguation or for linking resources by means of unique identifiers</h:span></h:a>
+                    </h:span>
+                <!--</xf:group>-->
+            </h:div>
+        </xf:group>
+
+        <xf:repeat nodeset="m:corpName" id="corp-relators-repeat">
+            <dcm:relator/>
+            <xi:include href="certainty-input.xml" parse="xml"/>
+            <dcm:authority/>
+            <!-- a more generic condition would have been nice but didn't work here -->
+            <dcm:element-buttons 
+                triggers="add remove up down" 
+                nodeset="m:corpName" 
+                index="corp-relators-repeat"
+                origin="xxf:instance('empty-instance')/m:meiHead/m:workList/m:work/m:contributor/m:corpName[1]"/>
+            <dcm:attribute-editor ref="."/>
+            <h:br/>
+        </xf:repeat>        
+    </xf:group>
 </h:div>

--- a/forms/includes/person-input.xml
+++ b/forms/includes/person-input.xml
@@ -12,10 +12,12 @@
         nodeset="m:persName"
         label="Add person"
         origin="xxf:instance('empty-instance')/m:meiHead/m:workList/m:work/m:contributor/m:persName"/>
+ 
     
     <xf:group ref="m:persName">
         <h:div class="blocklabel">
-            <h:span class="fixed_width_long">Name</h:span>
+            <h:span class="fixed_width_mediumlong">Name</h:span>
+            <h:span class="fixed_width"></h:span>
             <h:span class="fixed_width_mediumlong"> Relation <h:a class="help">&#160;?<h:span class="comment">Specifies the person's relation to the item, e.g. "Composer"
                 or "Author". The list is based on MARC relators as defined at http://id.loc.gov/vocabulary/relators</h:span></h:a>
             </h:span>
@@ -53,6 +55,5 @@
         <dcm:attribute-editor ref="."/>
         <h:br/>
     </xf:repeat>
-    
-    
+        
 </h:div>

--- a/forms/includes/person_list.xbl
+++ b/forms/includes/person_list.xbl
@@ -77,6 +77,17 @@
                         <xxf:value select="." xxbl:scope="outer"/>
                     </xf:var>
                         <xf:group ref=".[normalize-space($binding)]">
+                            <xf:action ev:event="xforms-enabled" if="count(@role)!=1">
+                                <xf:action if="$binding/local-name() = 'corpName'">
+                                    <!-- load rism country list -->
+                                    <xf:send submission="load-institutions"/>
+                                </xf:action>
+                                <xf:action if="$binding/local-name() = 'persName'">
+                                    <!-- load rism country list -->
+                                    <xf:send submission="load-persons"/>
+                                </xf:action>
+                            </xf:action>
+
                             <xf:var name="name" select="normalize-space($binding)"/>
                             <xf:group ref=".[not(instance('person-instance')//m:li/*/*[./text() = $name])]">
                                 <h:img src="{xxf:instance('parameters')/dcm:server_name}/editor/images/warning.png" style="vertical-align:middle;"

--- a/forms/includes/person_list.xbl
+++ b/forms/includes/person_list.xbl
@@ -97,13 +97,13 @@
                                     <xf:send submission="load-institutions"/>
                                 </xf:action>
 
-                                <xf:action if="not(@auth)">
+                                <xf:action if="not($binding/@auth)">
                                   <xf:insert nodeset="@*" context="$binding" origin="xxf:attribute('auth','')"/>
                                 </xf:action>
-                                <xf:action if="not(@auth.uri)">
+                                <xf:action if="not($binding/@auth.uri)">
                                   <xf:insert nodeset="@*" context="$binding" origin="xxf:attribute('auth.uri','')"/>
                                 </xf:action>
-                                <xf:action if="not(@codedval)">
+                                <xf:action if="not($binding/@codedval)">
                                   <xf:insert nodeset="@*" context="$binding" origin="xxf:attribute('codedval','')"/>
                                 </xf:action>
                                 <xf:var name="name" select="normalize-space($binding)"/>

--- a/forms/includes/person_list.xbl
+++ b/forms/includes/person_list.xbl
@@ -76,25 +76,8 @@
                     <xf:var name="binding" as="node()?">
                         <xxf:value select="." xxbl:scope="outer"/>
                     </xf:var>
-                        <xf:group ref=".[normalize-space($binding)]">
-                            <xf:action ev:event="xforms-enabled" if="count(@role)!=1">
-                                <xf:action if="$binding/local-name() = 'corpName'">
-                                    <!-- load rism country list -->
-                                    <xf:send submission="load-institutions"/>
-                                </xf:action>
-                                <xf:action if="$binding/local-name() = 'persName'">
-                                    <!-- load rism country list -->
-                                    <xf:send submission="load-persons"/>
-                                </xf:action>
-                            </xf:action>
-
-                            <xf:var name="name" select="normalize-space($binding)"/>
-                            <xf:group ref=".[not(instance('person-instance')//m:li/*/*[./text() = $name])]">
-                                <h:img src="{xxf:instance('parameters')/dcm:server_name}/editor/images/warning.png" style="vertical-align:middle;"
-                                    title="MerMEId does not recognize the person &apos;{$name}&apos;."/>
-                            </xf:group>
-                        </xf:group>
- 
+                    
+                    <xf:group ref=".[count(instance('person-instance')//m:li/*) > 0]"> 
                         <xf:trigger class="fixed_width">
                             <xf:label>Select from list</xf:label>
                             <xf:action ev:event="DOMActivate">
@@ -124,44 +107,64 @@
                                 <xxf:show dialog="person-dialog"/>
                             </xf:action>
                         </xf:trigger>
+                    </xf:group>
+
+                    <xf:group ref=".[normalize-space($binding)]">
+                        <xf:action ev:event="xforms-enabled" if="count(@role)!=1">
+                            <xf:action if="$binding/local-name() = 'corpName'">
+                                <!-- load rism country list -->
+                                <xf:send submission="load-institutions"/>
+                            </xf:action>
+                            <xf:action if="$binding/local-name() = 'persName'">
+                                <!-- load rism country list -->
+                                <xf:send submission="load-persons"/>
+                            </xf:action>
+                        </xf:action>
+
+                        <xf:var name="name" select="normalize-space($binding)"/>
+                        <xf:group ref=".[count(instance('person-instance')//m:li/*) > 0 and not(instance('person-instance')//m:li/*/*[./text() = $name])]">
+                            <h:img src="{xxf:instance('parameters')/dcm:server_name}/editor/images/warning.png" style="vertical-align:middle;"
+                                title="MerMEId does not recognize the person &apos;{$name}&apos;."/>
+                        </xf:group>
+                    </xf:group>
                         
-                        <xxf:dialog id="person-dialog" appearance="full" level="modal"
-                            close="true" draggable="true" visible="false">
-                            <xf:label>Person selection</xf:label>
-                            <xf:select1 ref="instance('temp')/id" xxf:refresh-items="false" class="maxlong">
-                                <xf:label class="fixed_width">Name</xf:label>
-                                <xf:item>
-                                    <xf:label>- Select name -</xf:label>
-                                    <xf:value/>
-                                </xf:item>
-                                <xf:itemset nodeset="instance('person-instance')//m:li/*">
-                                    <xf:label ref="./*[contains(@type, 'main')]"/>
-                                    <xf:value ref="./m:identifier[@auth='GND']/text()"/>
-                                </xf:itemset>
-                            </xf:select1>      
-                            <h:br/>&#160;
-                            <h:br/>
-                            <xf:trigger>
-                                <xf:label> OK </xf:label>
-                                <xf:action ev:event="DOMActivate">
-                                    <xf:var name="el" select="instance('person-instance')//m:li/*[./m:identifier[./text() = instance('temp')/id]]"/>
-                                    <xf:setvalue ref="instance('temp')/persName" value="$el/*[@type='main']"></xf:setvalue>
-                                    <xf:setvalue ref="$binding" value="instance('temp')/persName"></xf:setvalue>
-                                    <xf:setvalue ref="$binding/@codedval" value="instance('temp')/id"></xf:setvalue>
-                                    <xf:setvalue ref="$binding/@auth" value="$el/m:identifier[@auth]/@auth"></xf:setvalue>
-                                    <xf:setvalue ref="$binding/@auth.uri" value="$el/m:identifier[@auth]/@auth.uri"></xf:setvalue>
-                                    <xxf:hide dialog="person-dialog"/>
-                                </xf:action>
-                            </xf:trigger>
-                            <xf:trigger>
-                                <xf:label> Cancel </xf:label>
-                                <xf:action ev:event="DOMActivate">
-                                    <xxf:hide dialog="person-dialog"/>
-                                </xf:action>
-                            </xf:trigger>
-                        </xxf:dialog>
-                        
-                        <dcm:attribute-editor ref="$binding"/>
+                    <xxf:dialog id="person-dialog" appearance="full" level="modal"
+                        close="true" draggable="true" visible="false">
+                        <xf:label>Person selection</xf:label>
+                        <xf:select1 ref="instance('temp')/id" xxf:refresh-items="false" class="maxlong">
+                            <xf:label class="fixed_width">Name</xf:label>
+                            <xf:item>
+                                <xf:label>- Select name -</xf:label>
+                                <xf:value/>
+                            </xf:item>
+                            <xf:itemset nodeset="instance('person-instance')//m:li/*">
+                                <xf:label ref="./*[contains(@type, 'main')]"/>
+                                <xf:value ref="./m:identifier[@auth='GND']/text()"/>
+                            </xf:itemset>
+                        </xf:select1>      
+                        <h:br/>&#160;
+                        <h:br/>
+                        <xf:trigger>
+                            <xf:label> OK </xf:label>
+                            <xf:action ev:event="DOMActivate">
+                                <xf:var name="el" select="instance('person-instance')//m:li/*[./m:identifier[./text() = instance('temp')/id]]"/>
+                                <xf:setvalue ref="instance('temp')/persName" value="$el/*[@type='main']"></xf:setvalue>
+                                <xf:setvalue ref="$binding" value="instance('temp')/persName"></xf:setvalue>
+                                <xf:setvalue ref="$binding/@codedval" value="instance('temp')/id"></xf:setvalue>
+                                <xf:setvalue ref="$binding/@auth" value="$el/m:identifier[@auth]/@auth"></xf:setvalue>
+                                <xf:setvalue ref="$binding/@auth.uri" value="$el/m:identifier[@auth]/@auth.uri"></xf:setvalue>
+                                <xxf:hide dialog="person-dialog"/>
+                            </xf:action>
+                        </xf:trigger>
+                        <xf:trigger>
+                            <xf:label> Cancel </xf:label>
+                            <xf:action ev:event="DOMActivate">
+                                <xxf:hide dialog="person-dialog"/>
+                            </xf:action>
+                        </xf:trigger>
+                    </xxf:dialog>
+                    
+                    <dcm:attribute-editor ref="$binding"/>
                 </xf:group>
             </xf:group>
         </xbl:template>

--- a/forms/includes/person_list.xbl
+++ b/forms/includes/person_list.xbl
@@ -42,6 +42,15 @@
                     resource="{xxf:instance('parameters')/dcm:library_crud_home}persons.xml"
                     replace="instance" 
                     instance="person-instance"/>
+
+                <xf:submission id="load-institutions"
+                    xxf:show-progress="false"
+                    method="get" 
+                    serialization="none" 
+                    validate="false"
+                    resource="{xxf:instance('parameters')/dcm:library_crud_home}institutions.xml"
+                    replace="instance" 
+                    instance="person-instance"/>
                                 
                 <xf:instance id="temp">
                     <temp>
@@ -51,10 +60,6 @@
                 </xf:instance> 
                 
                 <!-- "onload" xforms actions -->
-                <xf:action ev:event="xforms-model-construct-done">
-                    <!-- load rism country list -->
-                    <xf:send submission="load-persons"/>
-                </xf:action>
                 
                 <xf:action ev:event="xforms-submit-error"  ev:propagate="stop">
                     <xf:var name="code" select="event('response-status-code')"/>
@@ -71,23 +76,36 @@
                     <xf:var name="binding" as="node()?">
                         <xxf:value select="." xxbl:scope="outer"/>
                     </xf:var>
-                        <!-- 
-                        <xf:input ref="$binding" id="person-input">
-                            <xf:label class="fixed_width">Name</xf:label>
-                        </xf:input>
-                         -->
-                        <!-- validate RISM siglum basic pattern and country -->              
                         <xf:group ref=".[normalize-space($binding)]">
                             <xf:var name="name" select="normalize-space($binding)"/>
-                            <xf:group ref=".[not(instance('person-instance')//m:li/m:persName/m:persName[./text() = $name])]">
+                            <xf:group ref=".[not(instance('person-instance')//m:li/*/*[./text() = $name])]">
                                 <h:img src="{xxf:instance('parameters')/dcm:server_name}/editor/images/warning.png" style="vertical-align:middle;"
-                                    title="MerMEId does not recognize the person &apos;{$name}&apos;. Please make sure you have entered a valid country code (all upper case)."/>
+                                    title="MerMEId does not recognize the person &apos;{$name}&apos;."/>
                             </xf:group>
                         </xf:group>
-                        
-                    <xf:trigger class="fixed_width">
+ 
+                        <xf:trigger class="fixed_width">
                             <xf:label>Select from list</xf:label>
                             <xf:action ev:event="DOMActivate">
+                                <xf:action if="$binding/local-name() = 'persName'">
+                                    <!-- load rism country list -->
+                                    <xf:send submission="load-persons"/>
+                                </xf:action>
+
+                                <xf:action if="$binding/local-name() = 'corpName'">
+                                    <!-- load rism country list -->
+                                    <xf:send submission="load-institutions"/>
+                                </xf:action>
+
+                                <xf:action if="not(@auth)">
+                                  <xf:insert nodeset="@*" context="$binding" origin="xxf:attribute('auth','')"/>
+                                </xf:action>
+                                <xf:action if="not(@auth.uri)">
+                                  <xf:insert nodeset="@*" context="$binding" origin="xxf:attribute('auth.uri','')"/>
+                                </xf:action>
+                                <xf:action if="not(@codedval)">
+                                  <xf:insert nodeset="@*" context="$binding" origin="xxf:attribute('codedval','')"/>
+                                </xf:action>
                                 <xf:var name="name" select="normalize-space($binding)"/>
                                 <xf:var name="id" select="$binding/@codedval"/>
                                 <xf:setvalue ref="instance('temp')/persName" value="$name"/>
@@ -105,9 +123,9 @@
                                     <xf:label>- Select name -</xf:label>
                                     <xf:value/>
                                 </xf:item>
-                                <xf:itemset nodeset="instance('person-instance')//m:li/m:persName">
-                                    <xf:label ref="./m:persName[@type='main']"/>
-                                    <xf:value ref="./@xml:id"/>
+                                <xf:itemset nodeset="instance('person-instance')//m:li/*">
+                                    <xf:label ref="./*[contains(@type, 'main')]"/>
+                                    <xf:value ref="./m:identifier[@auth='GND']/text()"/>
                                 </xf:itemset>
                             </xf:select1>      
                             <h:br/>&#160;
@@ -115,9 +133,12 @@
                             <xf:trigger>
                                 <xf:label> OK </xf:label>
                                 <xf:action ev:event="DOMActivate">
-                                    <xf:setvalue ref="instance('temp')/persName" value="instance('person-instance')//m:li/m:persName[@xml:id = instance('temp')/id]/m:persName[@type='main']"></xf:setvalue>
+                                    <xf:var name="el" select="instance('person-instance')//m:li/*[./m:identifier[./text() = instance('temp')/id]]"/>
+                                    <xf:setvalue ref="instance('temp')/persName" value="$el/*[@type='main']"></xf:setvalue>
                                     <xf:setvalue ref="$binding" value="instance('temp')/persName"></xf:setvalue>
                                     <xf:setvalue ref="$binding/@codedval" value="instance('temp')/id"></xf:setvalue>
+                                    <xf:setvalue ref="$binding/@auth" value="$el/m:identifier[@auth]/@auth"></xf:setvalue>
+                                    <xf:setvalue ref="$binding/@auth.uri" value="$el/m:identifier[@auth]/@auth.uri"></xf:setvalue>
                                     <xxf:hide dialog="person-dialog"/>
                                 </xf:action>
                             </xf:trigger>

--- a/forms/includes/person_list.xbl
+++ b/forms/includes/person_list.xbl
@@ -1,0 +1,137 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<xbl:xbl xmlns:h="http://www.w3.org/1999/xhtml"
+    xmlns:xf="http://www.w3.org/2002/xforms"
+    xmlns:xxf="http://orbeon.org/oxf/xml/xforms"
+    xmlns:xbl="http://www.w3.org/ns/xbl"
+    xmlns:xxbl="http://orbeon.org/oxf/xml/xbl"
+    xmlns:dcm="http://www.kb.dk/dcm"
+    xmlns:ev="http://www.w3.org/2001/xml-events"
+    xmlns:marc="http://www.loc.gov/MARC21/slim"
+    xmlns:zs="http://www.loc.gov/zing/srw/"
+    xmlns:xi="http://www.w3.org/2001/XInclude">
+    
+    <!--
+    Component to select a RISM siglum from lists of countries and archives.
+    Danish Centre for Music Editing (DCM) 
+    Axel Teich Geertinger, 2012
+    atge@kb.dk
+  -->
+    
+    <xbl:binding id="dcm-person-list-binding" element="dcm|person-list">
+        <metadata xmlns="http://orbeon.org/oxf/xml/form-builder">
+            <display-name lang="en">Person selection component</display-name>
+        </metadata>
+        
+        <xbl:resources>
+            <xbl:style/>
+        </xbl:resources>
+        <xbl:implementation>
+            <!-- Local model -->
+            <xf:model id="person-model">
+                <xf:instance xmlns="http://www.music-encoding.org/ns/mei"
+                    id="person-instance">
+                    <list/>
+                </xf:instance>
+                                
+                <xf:submission id="load-persons"
+                    xxf:show-progress="false"
+                    method="get" 
+                    serialization="none" 
+                    validate="false"
+                    resource="{xxf:instance('parameters')/dcm:library_crud_home}persons.xml"
+                    replace="instance" 
+                    instance="person-instance"/>
+                                
+                <xf:instance id="temp">
+                    <temp>
+                        <persName/>
+                        <id/>
+                    </temp>
+                </xf:instance> 
+                
+                <!-- "onload" xforms actions -->
+                <xf:action ev:event="xforms-model-construct-done">
+                    <!-- load rism country list -->
+                    <xf:send submission="load-persons"/>
+                </xf:action>
+                
+                <xf:action ev:event="xforms-submit-error"  ev:propagate="stop">
+                    <xf:var name="code" select="event('response-status-code')"/>
+                    <xf:message>Error. Submission return code: <xf:output value="$code"/></xf:message>
+                </xf:action>
+                
+            </xf:model>
+            
+        </xbl:implementation>
+        
+        <xbl:template>
+            <xf:group xbl:attr="model context ref bind" xxbl:scope="outer">
+                <xf:group appearance="xxf:internal" xxbl:scope="inner">
+                    <xf:var name="binding" as="node()?">
+                        <xxf:value select="." xxbl:scope="outer"/>
+                    </xf:var>
+                        <!-- 
+                        <xf:input ref="$binding" id="person-input">
+                            <xf:label class="fixed_width">Name</xf:label>
+                        </xf:input>
+                         -->
+                        <!-- validate RISM siglum basic pattern and country -->              
+                        <xf:group ref=".[normalize-space($binding)]">
+                            <xf:var name="name" select="normalize-space($binding)"/>
+                            <xf:group ref=".[not(instance('person-instance')//m:li/m:persName/m:persName[./text() = $name])]">
+                                <h:img src="{xxf:instance('parameters')/dcm:server_name}/editor/images/warning.png" style="vertical-align:middle;"
+                                    title="MerMEId does not recognize the person &apos;{$name}&apos;. Please make sure you have entered a valid country code (all upper case)."/>
+                            </xf:group>
+                        </xf:group>
+                        
+                    <xf:trigger class="fixed_width">
+                            <xf:label>Select from list</xf:label>
+                            <xf:action ev:event="DOMActivate">
+                                <xf:var name="name" select="normalize-space($binding)"/>
+                                <xf:var name="id" select="$binding/@codedval"/>
+                                <xf:setvalue ref="instance('temp')/persName" value="$name"/>
+                                <xf:setvalue ref="instance('temp')/id" value="$id"/>
+                                <xxf:show dialog="person-dialog"/>
+                            </xf:action>
+                        </xf:trigger>
+                        
+                        <xxf:dialog id="person-dialog" appearance="full" level="modal"
+                            close="true" draggable="true" visible="false">
+                            <xf:label>Person selection</xf:label>
+                            <xf:select1 ref="instance('temp')/id" xxf:refresh-items="false" class="maxlong">
+                                <xf:label class="fixed_width">Name</xf:label>
+                                <xf:item>
+                                    <xf:label>- Select name -</xf:label>
+                                    <xf:value/>
+                                </xf:item>
+                                <xf:itemset nodeset="instance('person-instance')//m:li/m:persName">
+                                    <xf:label ref="./m:persName[@type='main']"/>
+                                    <xf:value ref="./@xml:id"/>
+                                </xf:itemset>
+                            </xf:select1>      
+                            <h:br/>&#160;
+                            <h:br/>
+                            <xf:trigger>
+                                <xf:label> OK </xf:label>
+                                <xf:action ev:event="DOMActivate">
+                                    <xf:setvalue ref="instance('temp')/persName" value="instance('person-instance')//m:li/m:persName[@xml:id = instance('temp')/id]/m:persName[@type='main']"></xf:setvalue>
+                                    <xf:setvalue ref="$binding" value="instance('temp')/persName"></xf:setvalue>
+                                    <xf:setvalue ref="$binding/@codedval" value="instance('temp')/id"></xf:setvalue>
+                                    <xxf:hide dialog="person-dialog"/>
+                                </xf:action>
+                            </xf:trigger>
+                            <xf:trigger>
+                                <xf:label> Cancel </xf:label>
+                                <xf:action ev:event="DOMActivate">
+                                    <xxf:hide dialog="person-dialog"/>
+                                </xf:action>
+                            </xf:trigger>
+                        </xxf:dialog>
+                        
+                        <dcm:attribute-editor ref="$binding"/>
+                </xf:group>
+            </xf:group>
+        </xbl:template>
+    </xbl:binding>
+</xbl:xbl>

--- a/forms/includes/person_list.xbl
+++ b/forms/includes/person_list.xbl
@@ -100,6 +100,9 @@
                                 <xf:action if="not($binding/@codedval)">
                                   <xf:insert nodeset="@*" context="$binding" origin="xxf:attribute('codedval','')"/>
                                 </xf:action>
+                                <xf:action if="not($binding/@corresp)">
+                                  <xf:insert nodeset="@*" context="$binding" origin="xxf:attribute('corresp','')"/>
+                                </xf:action>
                                 <xf:var name="name" select="normalize-space($binding)"/>
                                 <xf:var name="id" select="$binding/@codedval"/>
                                 <xf:setvalue ref="instance('temp')/persName" value="$name"/>
@@ -151,6 +154,7 @@
                                 <xf:setvalue ref="instance('temp')/persName" value="$el/*[@type='main']"></xf:setvalue>
                                 <xf:setvalue ref="$binding" value="instance('temp')/persName"></xf:setvalue>
                                 <xf:setvalue ref="$binding/@codedval" value="instance('temp')/id"></xf:setvalue>
+                                <xf:setvalue ref="$binding/@corresp" value="$el/m:identifier[@label = 'Register-ID']/text()"></xf:setvalue>
                                 <xf:setvalue ref="$binding/@auth" value="$el/m:identifier[@auth]/@auth"></xf:setvalue>
                                 <xf:setvalue ref="$binding/@auth.uri" value="$el/m:identifier[@auth]/@auth.uri"></xf:setvalue>
                                 <xxf:hide dialog="person-dialog"/>

--- a/forms/includes/relator.xbl
+++ b/forms/includes/relator.xbl
@@ -42,6 +42,7 @@
             <xf:action ev:event="xforms-value-changed xforms-enabled"/>
           </xf:var>
           
+          
           <xf:input class="mediumlong" ref="$binding">
             <xf:action ev:event="xforms-enabled" if="count(@role)!=1">
               <!-- add role attribute -->
@@ -49,7 +50,9 @@
             </xf:action>
           </xf:input>
           <xf:var name="role" select="$binding/@role"/>
-
+          
+          <dcm:person-list ref="$binding"></dcm:person-list>
+          
           <!-- display a warning if role is not on standard relators list -->
           <xf:group ref=".[$role and not(xxf:instance('relators-instance')/role[.=$role])]">
             <xf:output value="$binding/@role"/>
@@ -61,8 +64,6 @@
                 should be used.</h:span>
             </h:a>
           </xf:group>
-
-          <dcm:person-list ref="$binding"></dcm:person-list>
 
           <xf:select1 ref="$binding/@role" class="mediumlong">
             <xf:itemset nodeset="xxf:instance('relators-instance')/role">

--- a/forms/includes/relator.xbl
+++ b/forms/includes/relator.xbl
@@ -55,7 +55,6 @@
           
           <!-- display a warning if role is not on standard relators list -->
           <xf:group ref=".[$role and not(xxf:instance('relators-instance')/role[.=$role])]">
-            <xf:output value="$binding/@role"/>
             <h:a class="help_plain">
               <h:img src="{xxf:instance('parameters')/dcm:server_name}/editor/images/warning.png"
                 alt="warning"/>

--- a/forms/includes/relator.xbl
+++ b/forms/includes/relator.xbl
@@ -11,7 +11,7 @@
     Axel Teich Geertinger, 2012–2015
     atge@kb.dk
   -->
-
+  
   <xbl:binding id="dcm-relator-binding" element="dcm|relator">
 
     <!-- Orbeon Form Builder Component Metadata -->
@@ -41,8 +41,8 @@
             <!-- initialization -->
             <xf:action ev:event="xforms-value-changed xforms-enabled"/>
           </xf:var>
-
-          <xf:input class="long" ref="$binding">
+          
+          <xf:input class="mediumlong" ref="$binding">
             <xf:action ev:event="xforms-enabled" if="count(@role)!=1">
               <!-- add role attribute -->
               <xf:insert nodeset="@*" context="." origin="xxf:attribute('role','')"/>
@@ -61,6 +61,8 @@
                 should be used.</h:span>
             </h:a>
           </xf:group>
+
+          <dcm:person-list ref="$binding"></dcm:person-list>
 
           <xf:select1 ref="$binding/@role" class="mediumlong">
             <xf:itemset nodeset="xxf:instance('relators-instance')/role">

--- a/forms/main_form_music.xml
+++ b/forms/main_form_music.xml
@@ -245,12 +245,12 @@
 					</h:fieldset>
 					
 					<h:fieldset>
-						<h:legend>Persons <h:a class="help">&#160;?<h:span 
+						<h:legend>Contributors <h:a class="help">&#160;?<h:span 
 							class="comment">Persons with connection to this particular version
 							only, e.g. an arranger, or a text author in a collection of songs 
 							with different authors</h:span></h:a></h:legend>	
 						<dcm:create nodeset="m:contributor"
-							label="Add persons"
+							label="Add contributors"
 							origin="instance('empty-instance')/m:meiHead/m:workList/m:work/m:expressionList/m:expression/m:contributor"/>
 						<xf:group ref="m:contributor">
 							<xi:include href="includes/person-input.xml"/>

--- a/forms/main_form_work.xml
+++ b/forms/main_form_work.xml
@@ -196,11 +196,11 @@
 			</h:fieldset>
 
 			<h:fieldset>
-				<h:legend>Persons <h:a class="help">&#160;?<h:span class="comment">A list of person
+				<h:legend>Contributors <h:a class="help">&#160;?<h:span class="comment">A list of person
 							involved in the creation or transmission of this work in general, such
 							as the composer or text author</h:span></h:a></h:legend>
 				<dcm:create ref="instance('data-instance')/m:meiHead/m:workList/m:work"
-					nodeset="m:contributor" label="Add person"
+					nodeset="m:contributor" label="Add contributor"
 					origin="instance('empty-instance')/m:meiHead/m:workList/m:work/m:contributor"/>
 				<xf:group ref="instance('data-instance')/m:meiHead/m:workList/m:work/m:contributor">
 					<xi:include href="includes/person-input.xml"/>

--- a/forms/model/empty_doc.xml
+++ b/forms/model/empty_doc.xml
@@ -68,6 +68,7 @@
             <title type="text_source" xml:lang="en"/>
             <contributor>
                <persName role="composer"/>
+               <corpName/>
             </contributor>
             <creation>
                <date isodate="" startdate="" enddate="" notbefore="" notafter=""/>

--- a/forms/model/empty_doc.xml
+++ b/forms/model/empty_doc.xml
@@ -89,6 +89,7 @@
                      <geogName role="place"/>
                      <corpName role="ensemble"/>
                      <persName role="conductor"/>
+                     <corpName role=""/>
                      <desc/>
                      <biblList>
                         <head>Reviews</head>
@@ -309,6 +310,7 @@
                <title/>
                <respStmt>
                   <persName role=""/>
+                  <corpName/>
                </respStmt>
             </titleStmt>
             <pubStmt>
@@ -355,7 +357,7 @@
                      <dimensions unit=""/>
                      <handList>
                         <hand medium="" type="main">
-                           <p n="MerMEId_temporary_wrapper"/>
+                           <persName n="MerMEId_temporary_wrapper"/>
                         </hand>
                      </handList>
                      <watermark/>

--- a/forms/model/new_file.xml
+++ b/forms/model/new_file.xml
@@ -54,6 +54,7 @@
             <title xml:lang="en"/>
             <contributor>
                <persName role="composer"/>
+               <corpName/>
             </contributor>
             <creation>
                <date/>

--- a/library/institutions.schema.xml
+++ b/library/institutions.schema.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<list xml:id="mei_5607df02-a8c8-4760-a721-4336707cc0da" xmlns="http://www.music-encoding.org/ns/mei" xmlns:xl="http://www.w3.org/1999/xlink">
+    <head>Institutions</head>
+    <li>
+   		<corpName>
+		    <corpName type="main">Bradford Festival Choral Society</corpName>
+		    <corpName type="alternative">Public Free Libraries and Art Museum Committee</corpName>
+		    <identifier label="Register-ID" codedval="154">154</identifier>
+		    <identifier auth="GND" auth.uri="https://d-nb.info/gnd/">1076575978</identifier>
+		    <persName role="director">
+		        <famName>Leech</famName>
+		        <foreName>Thomas</foreName>
+		    </persName>
+		    <geogName>
+		        <country>Großbritannien</country>
+		        <region>England</region>
+		        <district>West Yorkshire</district>
+		        <settlement>Bradford</settlement>
+		    </geogName>
+		    <date>
+		        <date type="establishment">
+		            <date isodate="1856">1856</date>
+		            <geogName/>
+		        </date>
+		        <date type="liquidation">
+		            <date/>
+		            <geogName/>
+		        </date>
+		    </date>
+		    <annot label="Kommentar">
+		        <p>Eintrag angelegt von MKl vor dem 30.11.17 // (Laut unserem  Besitzerverzeichnis: BRADFORD, Library of the Bradford Festival Choral Society, City Librarian, 
+		            Central Public Library, Darley Street, Bradford 1, Yorkshire; https://www.bradfordfestivalchoralsociety.org.uk/about-us/ [30.11.17]</p>
+		    </annot>
+		</corpName>
+	</li>
+</list>

--- a/library/institutions.xml
+++ b/library/institutions.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<list xml:id="mei_5607df02-a8c8-4760-a721-4336707cc0da" xmlns="http://www.music-encoding.org/ns/mei" xmlns:xl="http://www.w3.org/1999/xlink">
+   <head>Institutions</head>
+   <li></li></list>

--- a/library/institutions.xml
+++ b/library/institutions.xml
@@ -2,5 +2,37 @@
 <?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <list xml:id="mei_5607df02-a8c8-4760-a721-4336707cc0da" xmlns="http://www.music-encoding.org/ns/mei" xmlns:xl="http://www.w3.org/1999/xlink">
-   <head>Institutions</head>
-   <li></li></list>
+    <head>Institutions</head>
+    <li>
+   		<corpName>
+		    <corpName type="main">Bradford Festival Choral Society</corpName>
+		    <corpName type="alternative">Public Free Libraries and Art Museum Committee</corpName>
+		    <identifier label="Register-ID" codedval="154">154</identifier>
+		    <identifier auth="GND" auth.uri="https://d-nb.info/gnd/">1076575978</identifier>
+		    <persName role="director">
+		        <famName>Leech</famName>
+		        <foreName>Thomas</foreName>
+		    </persName>
+		    <geogName>
+		        <country>Großbritannien</country>
+		        <region>England</region>
+		        <district>West Yorkshire</district>
+		        <settlement>Bradford</settlement>
+		    </geogName>
+		    <date>
+		        <date type="establishment">
+		            <date isodate="1856">1856</date>
+		            <geogName/>
+		        </date>
+		        <date type="liquidation">
+		            <date/>
+		            <geogName/>
+		        </date>
+		    </date>
+		    <annot label="Kommentar">
+		        <p>Eintrag angelegt von MKl vor dem 30.11.17 // (Laut unserem  Besitzerverzeichnis: BRADFORD, Library of the Bradford Festival Choral Society, City Librarian, 
+		            Central Public Library, Darley Street, Bradford 1, Yorkshire; https://www.bradfordfestivalchoralsociety.org.uk/about-us/ [30.11.17]</p>
+		    </annot>
+		</corpName>
+	</li>
+</list>

--- a/library/institutions.xml
+++ b/library/institutions.xml
@@ -2,37 +2,5 @@
 <?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <list xml:id="mei_5607df02-a8c8-4760-a721-4336707cc0da" xmlns="http://www.music-encoding.org/ns/mei" xmlns:xl="http://www.w3.org/1999/xlink">
-    <head>Institutions</head>
-    <li>
-   		<corpName>
-		    <corpName type="main">Bradford Festival Choral Society</corpName>
-		    <corpName type="alternative">Public Free Libraries and Art Museum Committee</corpName>
-		    <identifier label="Register-ID" codedval="154">154</identifier>
-		    <identifier auth="GND" auth.uri="https://d-nb.info/gnd/">1076575978</identifier>
-		    <persName role="director">
-		        <famName>Leech</famName>
-		        <foreName>Thomas</foreName>
-		    </persName>
-		    <geogName>
-		        <country>Großbritannien</country>
-		        <region>England</region>
-		        <district>West Yorkshire</district>
-		        <settlement>Bradford</settlement>
-		    </geogName>
-		    <date>
-		        <date type="establishment">
-		            <date isodate="1856">1856</date>
-		            <geogName/>
-		        </date>
-		        <date type="liquidation">
-		            <date/>
-		            <geogName/>
-		        </date>
-		    </date>
-		    <annot label="Kommentar">
-		        <p>Eintrag angelegt von MKl vor dem 30.11.17 // (Laut unserem  Besitzerverzeichnis: BRADFORD, Library of the Bradford Festival Choral Society, City Librarian, 
-		            Central Public Library, Darley Street, Bradford 1, Yorkshire; https://www.bradfordfestivalchoralsociety.org.uk/about-us/ [30.11.17]</p>
-		    </annot>
-		</corpName>
-	</li>
-</list>
+   <head>Institutions</head>
+   <li></li></list>

--- a/library/persons.schema.xml
+++ b/library/persons.schema.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<list xml:id="mei_5607df02-a8c8-4760-a721-4336707cc0da" xmlns="http://www.music-encoding.org/ns/mei" xmlns:xl="http://www.w3.org/1999/xlink">
+	<head>Persons</head>
+	<li>
+   		<persName xml:id="example">
+			<persName type="main">Example</persName>
+			<persName type="alternative">Aischylos</persName>
+			<persName type="alternative">Aeschylus, Tragicus</persName>
+			<persName type="alternative">Aeschylos</persName>
+			<persName type="alternative">Aischylus</persName>
+			<persName type="alternative">Äschylus</persName>
+			<persName type="alternative">Aeschylus, Atheniensis</persName>
+			<persName type="alternative">Aischylos, von Eleusis</persName>
+			<persName type="alternative">Äschylos</persName>
+			<persName type="alternative">Eschylus</persName>
+			<identifier label="Register-ID" codedval="1">1</identifier>
+			<identifier auth="GND" auth.uri="https://d-nb.info/gnd/">118500856</identifier>
+			<famName/>
+			<foreName/>
+			<date>
+			<date type="birth">
+			   <date isodate="-525">525/524 v. Chr.</date>
+			   <geogName/>
+			</date>
+			<date type="death">
+			   <date isodate="-456">456 v. Chr </date>
+			   <geogName/>
+			</date>
+			</date>
+			<ptr label="OeML"/>
+			<ptr label="OeBL"/>
+			<annot label="Kurzbiographie">
+			<p/>
+			</annot>
+			<annot label="Informationen Privatbesitzer">
+			<p/>
+			</annot>
+			<annot label="Kommentar">
+			<p>Eintrag angelegt von MKl vor dem 30.11.17</p>
+			</annot>
+    	</persName>
+	</li>
+</list>

--- a/library/persons.xml
+++ b/library/persons.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<list xml:id="mei_5607df02-a8c8-4760-a721-4336707cc0da" xmlns="http://www.music-encoding.org/ns/mei" xmlns:xl="http://www.w3.org/1999/xlink">
+   <head>Persons</head>
+   <li></li></list>

--- a/library/persons.xml
+++ b/library/persons.xml
@@ -2,44 +2,6 @@
 <?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <list xml:id="mei_5607df02-a8c8-4760-a721-4336707cc0da" xmlns="http://www.music-encoding.org/ns/mei" xmlns:xl="http://www.w3.org/1999/xlink">
-	<head>Persons</head>
-	<li>
-   		<persName xml:id="example">
-			<persName type="main">Example</persName>
-			<persName type="alternative">Aischylos</persName>
-			<persName type="alternative">Aeschylus, Tragicus</persName>
-			<persName type="alternative">Aeschylos</persName>
-			<persName type="alternative">Aischylus</persName>
-			<persName type="alternative">Äschylus</persName>
-			<persName type="alternative">Aeschylus, Atheniensis</persName>
-			<persName type="alternative">Aischylos, von Eleusis</persName>
-			<persName type="alternative">Äschylos</persName>
-			<persName type="alternative">Eschylus</persName>
-			<identifier label="Register-ID" codedval="1">1</identifier>
-			<identifier auth="GND" auth.uri="https://d-nb.info/gnd/">118500856</identifier>
-			<famName/>
-			<foreName/>
-			<date>
-			<date type="birth">
-			   <date isodate="-525">525/524 v. Chr.</date>
-			   <geogName/>
-			</date>
-			<date type="death">
-			   <date isodate="-456">456 v. Chr </date>
-			   <geogName/>
-			</date>
-			</date>
-			<ptr label="OeML"/>
-			<ptr label="OeBL"/>
-			<annot label="Kurzbiographie">
-			<p/>
-			</annot>
-			<annot label="Informationen Privatbesitzer">
-			<p/>
-			</annot>
-			<annot label="Kommentar">
-			<p>Eintrag angelegt von MKl vor dem 30.11.17</p>
-			</annot>
-    	</persName>
-	</li>
+   <head>Persons</head>
+   <li></li>
 </list>

--- a/library/persons.xml
+++ b/library/persons.xml
@@ -2,5 +2,44 @@
 <?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <list xml:id="mei_5607df02-a8c8-4760-a721-4336707cc0da" xmlns="http://www.music-encoding.org/ns/mei" xmlns:xl="http://www.w3.org/1999/xlink">
-   <head>Persons</head>
-   <li></li></list>
+	<head>Persons</head>
+	<li>
+   		<persName xml:id="example">
+			<persName type="main">Example</persName>
+			<persName type="alternative">Aischylos</persName>
+			<persName type="alternative">Aeschylus, Tragicus</persName>
+			<persName type="alternative">Aeschylos</persName>
+			<persName type="alternative">Aischylus</persName>
+			<persName type="alternative">Äschylus</persName>
+			<persName type="alternative">Aeschylus, Atheniensis</persName>
+			<persName type="alternative">Aischylos, von Eleusis</persName>
+			<persName type="alternative">Äschylos</persName>
+			<persName type="alternative">Eschylus</persName>
+			<identifier label="Register-ID" codedval="1">1</identifier>
+			<identifier auth="GND" auth.uri="https://d-nb.info/gnd/">118500856</identifier>
+			<famName/>
+			<foreName/>
+			<date>
+			<date type="birth">
+			   <date isodate="-525">525/524 v. Chr.</date>
+			   <geogName/>
+			</date>
+			<date type="death">
+			   <date isodate="-456">456 v. Chr </date>
+			   <geogName/>
+			</date>
+			</date>
+			<ptr label="OeML"/>
+			<ptr label="OeBL"/>
+			<annot label="Kurzbiographie">
+			<p/>
+			</annot>
+			<annot label="Informationen Privatbesitzer">
+			<p/>
+			</annot>
+			<annot label="Kommentar">
+			<p>Eintrag angelegt von MKl vor dem 30.11.17</p>
+			</annot>
+    	</persName>
+	</li>
+</list>


### PR DESCRIPTION
For most occurrences, persName inputs are also allowed to input an institution corpName (except for the detailed publishing widget on File tab).
All person widgets have a "Select from list" function. To enable, populate library/persons.xml with a persons list of similar structure to library persons.schema.xml and the same with institutions.

note: hands widget is broken in this version as well as in develop so I didnt yet fix it, but will fix separately.