### PR TITLE
Forward session to exist for authentication

### DIFF
--- a/jetty-exist-additional-config/etc/webapp/WEB-INF/web.xml
+++ b/jetty-exist-additional-config/etc/webapp/WEB-INF/web.xml
@@ -67,6 +67,10 @@
          <param-value>UTF-8</param-value>
       </init-param>
    </servlet>
+    <context-param>
+    <param-name>org.eclipse.jetty.servlet.SessionCookie</param-name>
+    <param-value>XSESSIONID</param-value>
+  </context-param>
    <!--
         EXistServlet is a helper servlet that is used to ensure that
         eXist is running in the background.
@@ -91,6 +95,7 @@
          <param-name>basedir</param-name>
          <param-value>WEB-INF/</param-value>
       </init-param>
+
       <init-param>
          <param-name>start</param-name>
          <param-value>true</param-value>

--- a/orbeon-additional-config/WEB-INF/resources/config/properties-local.xml
+++ b/orbeon-additional-config/WEB-INF/resources/config/properties-local.xml
@@ -1,0 +1,8 @@
+<properties xmlns:xs="http://www.w3.org/2001/XMLSchema"
+            xmlns:oxf="http://www.orbeon.com/oxf/processors">
+    <!-- Renaming existdb session and the "DUMMY" refix is required to prevent Orbeon sending duplicate JSESSIONID -->
+    <property
+    as="xs:string"
+    name="oxf.http.forward-cookies"
+    value="DUMMY XSESSIONID"/>
+</properties>


### PR DESCRIPTION
* Use cookie forwarding feature of orbeon to enable authenticating against existdb and using that session for write access.
* Rename exist session to XSESSION and add a dummy value to orbeon config prevent orbeon mistakenly sending duplicate session cookies (http://discuss.orbeon.com/Problems-with-cookies-for-persistence-and-services-td4663655.html)

# How to test
Log in through eXide and then try updating an existing document in mermeid.