### PR TITLE
Add files to source reference options

### DIFF
--- a/forms/details-source.xml
+++ b/forms/details-source.xml
@@ -212,6 +212,66 @@
                                         </xf:select1>
                                     </h:td>
                                     <h:td>
+                                        <h:span> or select </h:span>
+                                    <xf:group ref="@target">
+                                        <xf:input ref="." class="maxlong">
+                                            <xf:label>URI <h:a class="help">&#160;?<h:span
+                                                class="comment">The location of the linked
+                                                ressource (target). The target may be either an
+                                                external file (such as
+                                                "http://www.example.org/some_file.xml"), an
+                                                internal reference to an element in the file you
+                                                are editing (by XML ID, such as "#source_1"), or a
+                                                combination of both (like
+                                                "http://www.example.org/some_file.xml#source_1").
+                                                <h:br/> The target URI may be entered manually or
+                                                selected using the "Select file" button.<h:br/>
+                                                Please note: in MerMEId's HTML preview, relative
+                                                URIs are interpreted as being links to other MEI
+                                                files to be displayed as MerMEId previews as well.
+                                                To avoid this, make the URI absolute (i.e.,
+                                                starting with a protocol like "http://").
+                                                </h:span></h:a>
+                                            </xf:label>
+                                        </xf:input>
+                                        <xf:trigger>
+                                            <xf:label><h:img
+                                                src="{instance('parameters')/dcm:server_name}/editor/images/search.png"
+                                                title="search for file" alt="search"/> Select file</xf:label>
+                                            <xf:action ev:event="DOMActivate">
+                                                <xf:setvalue ref="instance('temp')/nodeset"
+                                                value="&quot;instance(&apos;data-instance&apos;)/m:meiHead/m:manifestationList/m:manifestation[@xml:id=instance(&apos;temp&apos;)/id]/m:relationList/m:relation[index(&apos;work_relations&apos;)]&quot;"/>
+                                                <xxf:show dialog="relation_dialog"/>
+                                                <xf:setvalue ref="instance('temp')/target_uri"
+                                                value="concat(instance('parameters')/dcm:server_name,'/modules/cross-link.xq?get=works')"/>
+                                                <!-- load data on open - may be deactivated if performance is an issue -->
+                                                <xf:send submission="load-fileList"/>
+                                            </xf:action>
+                                        </xf:trigger>
+                                        <xf:trigger appearance="minimal">
+                                            <xf:label>
+                                                <h:span style="vertical-align:bottom;">
+                                                <h:img
+                                                src="{instance('parameters')/dcm:server_name}/editor/images/go_to_link.png"
+                                                title="Go to linked resource"/>
+                                                </h:span>
+                                            </xf:label>
+                                            <xf:action ev:event="DOMActivate">
+                                                <xf:var name="uri"
+                                                select="concat(
+                          instance('parameters')/dcm:orbeon_dir,
+                          '?uri=',
+                          instance('parameters')/dcm:form_home,
+                          'edit-work-case.xml&amp;doc=',.)"/>
+                                                <xf:setvalue ref="instance('temp')/target_uri"
+                                                value="$uri"/>
+                                                <xxf:show dialog="leave-warning-dialog"/>
+                                            </xf:action>
+                                        </xf:trigger>
+                                    </xf:group>
+
+                                    </h:td>
+                                    <h:td>
                                             <xf:input ref="@label" class="long">
                                             <xf:label> Target label <h:a class="help">&#160;?<h:span class="comment">The text to be 
                                               displayed as the target of the relation (for instance, the title or label of the source referred to).<h:br/>
@@ -231,6 +291,8 @@
                                         </h:span>
                                     </h:td>
                                 </h:tr>
+
+
                             </xf:repeat>
                         </h:table>
                     </h:fieldset>
@@ -317,6 +379,142 @@
 
                                                   <dcm:source-input/>
 
+                                                <!-- Relations -->
+                                                <h:fieldset>
+                                                    <h:legend>Relations <h:a class="help">&#160;?<h:span class="comment">Defines
+                                                        relations between this source and other sources (in FRBR terms: "manifestations"), 
+                                                        versions (FRBR: "expressions") of this work, other works etc.<h:br/> 
+                                                        Currently two relations are handled in a special way in MerMEId's HTML preview: the
+                                                                relation "is reproduction of" pointing to another source marks
+                                                                this source as being a reprint of the other source; the "is
+                                                                embodiment of" relation pointing to an expression (version) of
+                                                                the works is used to specify which particular version of the
+                                                                work is embodied by this source.<h:br/>
+                                                                All other relations will be displayed as [relation]: [label]. 
+                                                                If no label is specified, MerMEId displays the xml:id of the target instead. 
+                                                                <h:br/>Depending on the encoding pratice of your project,
+                                                                relations may or may not be defined mutually, i.e. the opposite
+                                                                relation may be defined on the target.<h:br/> The list of relations is based
+                                                                on FRBR relations (see
+                                                                http://www.ifla.org/files/cataloguing/frbr/frbr_2008.pdf).
+                                                            </h:span></h:a></h:legend>
+                                                    <dcm:create nodeset="m:relationList" label="Add relation"
+                                                        origin="instance('empty-instance')/m:meiHead/m:manifestationList/m:manifestation[1]/m:componentList/m:manifestation/m:relationList"/>
+                                                    <dcm:create ref="m:relationList" nodeset="m:relation" label="Add relation"
+                                                        origin="instance('empty-instance')/m:meiHead/m:manifestationList/m:manifestation[1]/m:componentList/m:manifestation/m:relation"/>
+                                                    <h:table class="element_list" cellspacing="0" cellpadding="0" border="0">
+                                                        <xf:repeat nodeset="m:relationList/m:relation" id="component_relations">
+                                                            <xf:var name="this_id" select="../../@xml:id"/>
+                                                            <h:tr>
+                                                                <h:td>
+                                                                    <h:span>This source </h:span>
+                                                                    <xi:include href="includes/relation_select.xml" parse="xml"/>
+                                                                    <xf:select1 ref="@target" class="long">
+                                                                        <xf:label/>
+                                                                        <xf:item>
+                                                                            <xf:label>- select target -</xf:label>
+                                                                            <xf:value/>
+                                                                        </xf:item>
+                                                                        <xf:itemset
+                                                                            nodeset="instance('data-instance')//m:manifestation/@xml:id[.!=$this_id] | instance('data-instance')//m:expression/@xml:id">
+                                                                            <xf:label>
+                                                                              <xf:output value="concat(../m:titleStmt/m:title[1],' (',.,')')"/>
+                                                                            </xf:label>
+                                                                            <xf:value ref="concat('#',.)"/>
+                                                                        </xf:itemset>
+                                                                        <xf:action ev:event="xforms-value-changed">
+                                                                            <!-- insert target label if empty -->
+                                                                            <xf:action if="../@label=''">
+                                                                                <xf:var name="target" select="translate(../@target,'#','')"/>
+                                                                                <xf:setvalue ref="../@label" value="instance('data-instance')//*[@xml:id=$target]/m:titleStmt/m:title[1]"/>
+                                                                            </xf:action>
+                                                                        </xf:action>
+                                                                    </xf:select1>
+                                                                </h:td>
+
+                                                                <h:td>
+                                                                    <h:span> or select </h:span>
+                                                                <xf:group ref="@target">
+                                                                    <xf:input ref="." class="maxlong">
+                                                                        <xf:label>URI <h:a class="help">&#160;?<h:span
+                                                                            class="comment">The location of the linked
+                                                                            ressource (target). The target may be either an
+                                                                            external file (such as
+                                                                            "http://www.example.org/some_file.xml"), an
+                                                                            internal reference to an element in the file you
+                                                                            are editing (by XML ID, such as "#source_1"), or a
+                                                                            combination of both (like
+                                                                            "http://www.example.org/some_file.xml#source_1").
+                                                                            <h:br/> The target URI may be entered manually or
+                                                                            selected using the "Select file" button.<h:br/>
+                                                                            Please note: in MerMEId's HTML preview, relative
+                                                                            URIs are interpreted as being links to other MEI
+                                                                            files to be displayed as MerMEId previews as well.
+                                                                            To avoid this, make the URI absolute (i.e.,
+                                                                            starting with a protocol like "http://").
+                                                                            </h:span></h:a>
+                                                                        </xf:label>
+                                                                    </xf:input>
+                                                                    <xf:trigger>
+                                                                        <xf:label><h:img
+                                                                            src="{instance('parameters')/dcm:server_name}/editor/images/search.png"
+                                                                            title="search for file" alt="search"/> Select file</xf:label>
+                                                                        <xf:action ev:event="DOMActivate">
+                                                                            <xf:setvalue ref="instance('temp')/nodeset"
+                                                                            value="&quot;instance(&apos;data-instance&apos;)/m:meiHead/m:manifestationList/m:manifestation[@xml:id=instance(&apos;temp&apos;)/id]/m:componentList/m:manifestation[index(&apos;repeat-source-component&apos;)]/m:relationList/m:relation[index(&apos;component_relations&apos;)]&quot;"/>
+                                                                            <xxf:show dialog="relation_dialog"/>
+                                                                            <xf:setvalue ref="instance('temp')/target_uri"
+                                                                            value="concat(instance('parameters')/dcm:server_name,'/modules/cross-link.xq?get=works')"/>
+                                                                            <!-- load data on open - may be deactivated if performance is an issue -->
+                                                                            <xf:send submission="load-fileList"/>
+                                                                        </xf:action>
+                                                                    </xf:trigger>
+                                                                    <xf:trigger appearance="minimal">
+                                                                        <xf:label>
+                                                                            <h:span style="vertical-align:bottom;">
+                                                                            <h:img
+                                                                            src="{instance('parameters')/dcm:server_name}/editor/images/go_to_link.png"
+                                                                            title="Go to linked resource"/>
+                                                                            </h:span>
+                                                                        </xf:label>
+                                                                        <xf:action ev:event="DOMActivate">
+                                                                            <xf:var name="uri"
+                                                                            select="concat(
+                                                      instance('parameters')/dcm:orbeon_dir,
+                                                      '?uri=',
+                                                      instance('parameters')/dcm:form_home,
+                                                      'edit-work-case.xml&amp;doc=',.)"/>
+                                                                            <xf:setvalue ref="instance('temp')/target_uri"
+                                                                            value="$uri"/>
+                                                                            <xxf:show dialog="leave-warning-dialog"/>
+                                                                        </xf:action>
+                                                                    </xf:trigger>
+                                                                </xf:group>
+
+                                                                </h:td>
+                                                                <h:td>
+                                                                        <xf:input ref="@label" class="long">
+                                                                        <xf:label> Target label <h:a class="help">&#160;?<h:span class="comment">The text to be 
+                                                                          displayed as the target of the relation (for instance, the title or label of the source referred to).<h:br/>
+                                                                          By default, MerMEId inserts the title of the element referred to (if any), but any text may be entered.<h:br/>
+                                                                          Please note that MerMEId displays labels containing a colon (:) in a special way: In
+                                                                          that case, the text before the colon is displayed as the relation label instead of the
+                                                                          standard description af the relation.</h:span></h:a></xf:label>
+                                                                        </xf:input>
+                                                                        </h:td>
+                                                                <h:td style="vertical-align:top; white-space:nowrap;">
+                                                                    <h:span class="editmenu">
+                                                                        <dcm:element-buttons
+                                                                            triggers="up down add del-parent-with-last"
+                                                                            nodeset="m:relation" index="component_relations"
+                                                                            origin="instance('empty-instance')/m:meiHead/m:workList/m:work/m:relationList/m:relation"/>
+                                                                        <dcm:attribute-editor/>
+                                                                    </h:span>
+                                                                </h:td>
+                                                            </h:tr>
+                                                        </xf:repeat>
+                                                    </h:table>
+                                                </h:fieldset>
 
                                                   <!-- Source component items -->
                                                   <h:fieldset> 
@@ -409,6 +607,6 @@
         <xi:include href="edit-form-footer.xml" parse="xml"/>
 
         <xi:include href="includes/code-inspector.xml" parse="xml"/>
-
+        <xi:include href="includes/relation-dialog.xml" parse="xml"/>
     </h:body>
 </h:html>

--- a/forms/details-source.xml
+++ b/forms/details-source.xml
@@ -398,7 +398,7 @@
                                                                 on FRBR relations (see
                                                                 http://www.ifla.org/files/cataloguing/frbr/frbr_2008.pdf).
                                                             </h:span></h:a></h:legend>
-                                                    <dcm:create nodeset="m:relationList" label="Add relation"
+                                                    <dcm:create nodeset="m:relationList" label="Add relations"
                                                         origin="instance('empty-instance')/m:meiHead/m:manifestationList/m:manifestation[1]/m:componentList/m:manifestation/m:relationList"/>
                                                     <dcm:create ref="m:relationList" nodeset="m:relation" label="Add relation"
                                                         origin="instance('empty-instance')/m:meiHead/m:manifestationList/m:manifestation[1]/m:componentList/m:manifestation/m:relation"/>

--- a/forms/model/empty_doc.xml
+++ b/forms/model/empty_doc.xml
@@ -505,6 +505,9 @@
                      <title/>
                   </titleStmt>
                   <physDesc/>
+                  <relationList>
+                     <relation rel="" label="" target=""/>
+                  </relationList>
                </manifestation>
             </componentList>
             <relationList>


### PR DESCRIPTION
"In order to map the overall structure between different manuscripts, it is necessary to be able to link to other files in the sources-tab.
For this purpose, the Select-File-Button in the relation function must be added. The same function already exists in works and music: in the file main_form_music.xml it is this function I would say."

![relations](https://user-images.githubusercontent.com/445895/102638122-504b3b80-4157-11eb-95e8-b2fec7b9736a.png)

## Testing 

Log in, open a file and go to Sources tab
Create a new source or open an existing one
Click on edit source button 
Under Relations fieldset click on "select file" 
Your should be able to select another document as the relation target

Add a new compoent to the source
Under Component > Relations widget, you should see the Select file button 
Click on Select file 
You should be able to select another document as the relation target