### PR TITLE
remove parameter `xslt.exist-dir`

### DIFF
--- a/data/controller.xql
+++ b/data/controller.xql
@@ -2,6 +2,8 @@ xquery version "3.0";
 
 declare namespace exist="http://exist.sourceforge.net/NS/exist";
 declare namespace request="http://exist-db.org/xquery/request";
+declare namespace response="http://exist-db.org/xquery/response";
+declare namespace transform="http://exist-db.org/xquery/transform";
 
 import module namespace config="https://github.com/edirom/mermeid/config" at "../modules/config.xqm";
 import module namespace xmldb="http://exist-db.org/xquery/xmldb";

--- a/data/controller.xql
+++ b/data/controller.xql
@@ -40,7 +40,6 @@ if (ends-with($exist:resource, ".xml")) then
                 <param name="xslt.exist-endpoint-seen-from-orbeon" value="{$config:exist-endpoint-seen-from-orbeon}"/>
                 <param name="xslt.orbeon-endpoint" value="{$config:orbeon-endpoint}"/>
                 <param name="xslt.server-name" value="{config:get-property('exist_endpoint')}"/>
-                <param name="xslt.exist-dir" value="/"/>
                 <param name="xslt.document-root" value="/data/"/>
                 <param name="exist:stop-on-warn" value="no"/>
                 <param name="exist:stop-on-error" value="no"/>

--- a/filter/xsl/mermeid_configuration.xsl
+++ b/filter/xsl/mermeid_configuration.xsl
@@ -9,7 +9,6 @@
     <xsl:param name="xslt.orbeon-endpoint"/>
     <xsl:param name="xslt.exist-endpoint-seen-from-orbeon"/>
     <xsl:param name="xslt.server-name"/>
-    <xsl:param name="xslt.exist-dir"/>
     <xsl:param name="xslt.document-root"/>
     
     <xsl:variable name="xforms-parameters" as="element(dcm:parameters)">
@@ -33,9 +32,6 @@
             <server_name>
                 <xsl:value-of select="$xslt.server-name"/>
             </server_name>  
-            <exist_dir>
-                <xsl:value-of select="$xslt.exist-dir"/>
-            </exist_dir>
             <document_root>
                 <xsl:value-of select="$xslt.document-root"/>
             </document_root>

--- a/forms/includes/incipit-input.xml
+++ b/forms/includes/incipit-input.xml
@@ -96,7 +96,7 @@
                         <xf:group ref=".[*]">
                                 <h:a 
                                     href="javascript:void(0);"
-                                    onclick="window.open('{instance('parameters')/dcm:server_name}{instance('parameters')/dcm:exist_dir}modules/view_score.xq?doc={instance('parameters')/dcm:xml_file}&amp;score_id={@xml:id}',
+                                    onclick="window.open('{instance('parameters')/dcm:server_name}/modules/view_score.xq?doc={instance('parameters')/dcm:xml_file}&amp;score_id={@xml:id}',
                                     '_blank', 'height=360,width=1090,location=no,status=no,menubar=no,toolbar=no');return false;"
                                     ><h:img src="{instance('parameters')/dcm:server_name}/editor/images/score.png" alt="Score" title="View incipit" 
                                         border="0" style="vertical-align:middle;"/></h:a>
@@ -208,7 +208,7 @@
                     <xf:group ref=".[text()]">
                         <h:a 
                             href="javascript:void(0);"
-                            onclick="window.open('{instance('parameters')/dcm:server_name}{instance('parameters')/dcm:exist_dir}modules/view_score.xq?doc={instance('parameters')/dcm:xml_file}&amp;mode=pae&amp;score_id={@xml:id}',
+                            onclick="window.open('{instance('parameters')/dcm:server_name}/modules/view_score.xq?doc={instance('parameters')/dcm:xml_file}&amp;mode=pae&amp;score_id={@xml:id}',
                             '_blank', 'height=200,width=1000,location=no,status=no,menubar=no,toolbar=no');return false;"
                             ><h:img src="{instance('parameters')/dcm:server_name}/editor/images/score.png" alt="Score" title="View incipit" 
                                 border="0" style="vertical-align:middle;"/></h:a>

--- a/forms/includes/topmenu.xml
+++ b/forms/includes/topmenu.xml
@@ -25,7 +25,7 @@
         <xf:setvalue ref="instance('temp')/changed" value="'false'"/>
       </xf:action>
     </xf:trigger><h:a 
-      href="{instance('parameters')/dcm:server_name}{instance('parameters')/dcm:exist_dir}modules/present.xq?doc={instance('parameters')/dcm:xml_file}"
+      href="{instance('parameters')/dcm:server_name}/modules/present.xq?doc={instance('parameters')/dcm:xml_file}"
       class="xforms-trigger" 
       target="view_{instance('parameters')/dcm:xml_file}"><h:img 
         src="{instance('parameters')/dcm:server_name}/editor/images/html.gif" alt="HTML" title="View as HTML" border="0"/></h:a><h:a 
@@ -38,12 +38,12 @@
         title="Close editor and return to file list" border="0"/></xf:label>
       <xf:action ev:event="DOMActivate">
         <xf:action if="instance('temp')/changed='true'">
-          <xf:var name="uri" select="concat(instance('parameters')/dcm:server_name,instance('parameters')/dcm:exist_dir,'modules/list_files.xq')"/>
+          <xf:var name="uri" select="concat(instance('parameters')/dcm:server_name,'/modules/list_files.xq')"/>
           <xf:setvalue ref="instance('temp')/target_uri" value="$uri"/>
           <xxf:show dialog="exit-warning-dialog"/>
         </xf:action>	
         <xf:action if="instance('temp')/changed='false'">
-          <xf:load resource="{instance('parameters')/dcm:server_name}{instance('parameters')/dcm:exist_dir}modules/list_files.xq" show="replace"/>
+          <xf:load resource="{instance('parameters')/dcm:server_name}/modules/list_files.xq" show="replace"/>
         </xf:action>
       </xf:action>
     </xf:trigger><xf:trigger appearance="minimal">

--- a/modules/transform.xq
+++ b/modules/transform.xq
@@ -17,6 +17,5 @@ return transform:transform($inputDoc, doc(request:get-attribute('transform.style
                 <param name="xslt.exist-endpoint-seen-from-orbeon" value="{$config:exist-endpoint-seen-from-orbeon}"/>
                 <param name="xslt.orbeon-endpoint" value="{$config:orbeon-endpoint}"/>
                 <param name="xslt.server-name" value="{config:get-property('exist_endpoint')}"/>
-                <param name="xslt.exist-dir" value="/"/>
                 <param name="xslt.document-root" value="/data/"/>
 </parameters>, <attributes></attributes>, "method=xml media-type=application/xml")

--- a/modules/transform.xq
+++ b/modules/transform.xq
@@ -1,12 +1,14 @@
 xquery version "3.1";
 
-declare option exist:serialize "method=xml media-type=application/xml";
+declare namespace exist="http://exist.sourceforge.net/NS/exist";
 
 import module namespace transform = "http://exist-db.org/xquery/transform";
 
 import module namespace config="https://github.com/edirom/mermeid/config" at "config.xqm";
 
 import module namespace console="http://exist-db.org/xquery/console";
+
+declare option exist:serialize "method=xml media-type=application/xml";
 
 let $inputDoc := (doc(request:get-attribute('transform.doc')), request:get-data())[1]
 

--- a/style/gw_source_descriptions.xsl
+++ b/style/gw_source_descriptions.xsl
@@ -42,10 +42,10 @@
 	</xsl:variable>
 	<!-- files containing look-up information -->
 	<xsl:variable name="bibl_file_name"
-		select="string(concat('http://',$hostname,'/',$settings/dcm:parameters/dcm:exist_dir,'library/standard_bibliography.xml'))"/>
+		select="string(concat('http://',$hostname,'/library/standard_bibliography.xml'))"/>
 	<xsl:variable name="bibl_file" select="document($bibl_file_name)"/>
 	<xsl:variable name="abbreviations_file_name"
-		select="string(concat('http://',$hostname,'/',$settings/dcm:parameters/dcm:exist_dir,'library/abbreviations.xml'))"/>
+		select="string(concat('http://',$hostname,'/library/abbreviations.xml'))"/>
 	<xsl:variable name="abbreviations_file" select="document($abbreviations_file_name)"/>
 
 

--- a/style/mei_to_html.xsl
+++ b/style/mei_to_html.xsl
@@ -600,7 +600,7 @@
 		<xsl:variable name="href">
 			<xsl:choose>
 				<xsl:when test="$mermeid_crossref='true'">
-					<xsl:value-of select="concat($settings/dcm:parameters/dcm:server_name,$settings/dcm:parameters/dcm:exist_dir,'present.xq?doc=',@target)"/>
+					<xsl:value-of select="concat($settings/dcm:parameters/dcm:server_name,'/present.xq?doc=',@target)"/>
 				</xsl:when>
 				<xsl:otherwise>
 					<xsl:value-of select="@target"/>

--- a/style/mei_to_html_print_short.xsl
+++ b/style/mei_to_html_print_short.xsl
@@ -107,7 +107,7 @@
 		<xsl:variable name="href">
 			<xsl:choose>
 				<xsl:when test="$mermeid_crossref='true'">
-					<xsl:value-of select="concat($settings/dcm:parameters/dcm:server_name,$settings/dcm:parameters/dcm:exist_dir,'present.xq?doc=',@target)"/>
+					<xsl:value-of select="concat($settings/dcm:parameters/dcm:server_name,'/present.xq?doc=',@target)"/>
 				</xsl:when>
 				<xsl:otherwise>
 					<xsl:value-of select="@target"/>


### PR DESCRIPTION
this PR will close #34 by removing all occurences of `xslt.exist-dir` (in Stylesheets) and `exist_dir` (in XForms). In the XForms the variable got replaced by a simple Slash as path separator.

These params/variables are superfluous now since `exist_endpoint` already holds the full path (including `$exist:prefix)` to the MerMEId installation.

I tried to single out the necessary changes  (including some cosmetic changes, i.e. adding some namespaces) in separate commits for facilitating the review. These commits can be squashed on merge.