### PR TITLE
add first GitHub Actions for building and testing 

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -1,0 +1,23 @@
+name: Artifacts
+
+on: push
+
+jobs:
+  build:
+    name: build the MerMEId xar package
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Build with Ant
+        run: ant clean xar
+      - name: Archive xar package
+        uses: actions/upload-artifact@v2
+        with:
+          name: xar-package
+          path: build/*.xar

--- a/.github/workflows/docker-testing.yml
+++ b/.github/workflows/docker-testing.yml
@@ -15,10 +15,4 @@ jobs:
       - name: Run Docker image
         run: docker run --rm -p 8080:8080 -d mermeid
       - name: Check the deployed service URL
-        uses: jtalk/url-health-check-action@v1.5
-        with:
-          url: http://localhost:8080/index.html
-          follow-redirect: no
-          max-attempts: 5
-          retry-delay: 20s
-          retry-all: no
+        run: curl --fail -sv  http://localhost:8080/index.html --retry 5 --retry-delay 20 --retry-connrefused 

--- a/.github/workflows/docker-testing.yml
+++ b/.github/workflows/docker-testing.yml
@@ -15,4 +15,5 @@ jobs:
       - name: Run Docker image
         run: docker run --rm -p 8080:8080 -d mermeid
       - name: Check the deployed service URL
-        run: curl --fail -sv  http://localhost:8080/index.html --retry 5 --retry-delay 20 --retry-connrefused 
+        run: i=0 ; while (! curl --fail -sv http://localhost:8080/index.html) ; do if ((i > 20)) ; then echo ' **** timeout ... aborting **** ' ; exit 1 ; else sleep 5 ; echo waiting for container ... ; i=$((i+1)) ; fi ; done
+

--- a/.github/workflows/docker-testing.yml
+++ b/.github/workflows/docker-testing.yml
@@ -1,0 +1,24 @@
+name: Docker Testing
+
+on: push
+
+jobs:
+  build:
+    name: Build the Docker image
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Build Docker image
+        run: docker build -t mermeid .
+      - name: Run Docker image
+        run: docker run --rm -p 8080:8080 -d mermeid
+      - name: Check the deployed service URL
+        uses: jtalk/url-health-check-action@v1.5
+        with:
+          url: http://localhost:8080/index.html
+          follow-redirect: no
+          max-attempts: 5
+          retry-delay: 20s
+          retry-all: yes

--- a/.github/workflows/docker-testing.yml
+++ b/.github/workflows/docker-testing.yml
@@ -21,4 +21,4 @@ jobs:
           follow-redirect: no
           max-attempts: 5
           retry-delay: 20s
-          retry-all: yes
+          retry-all: no


### PR DESCRIPTION
This PR adds two actions:
"Artifcats": for building the xar package
"Docker testing": for a very basic test whether the HTTP status code of the index page (of the current built) is ok

This may serve as a starting point for additional tests, see #41

NB: These actions are already in place due to some GitHub magic (regardless the status of this PR), see https://github.com/Edirom/MerMEId/actions