### PR TITLE
Fix both problems related to missing bibliography types

### DIFF
--- a/forms/details-form-model.xml
+++ b/forms/details-form-model.xml
@@ -174,6 +174,15 @@
         instance="XMLfiles"
         xxf:show-progress="true"/>
     
+    <xf:submission id="load-bibl-types" 
+        xxf:show-progress="true" 
+        method="get" 
+        serialization="none" 
+        validate="false" 
+        resource="{instance('parameters')/dcm:library_crud_home}/bibl_reference_types.xml" 
+        replace="instance" 
+        instance="bibl-type-instance"/>
+        
     <xf:submission id="load-bibliography"
         method="get" 
         serialization="none" 
@@ -274,6 +283,7 @@
         <!-- load reference data from library -->
         <xf:send submission="load-authorities"/>
         <xf:send submission="load-classification"/>
+        <xf:send submission="load-bibl-types"/>
         <xf:send submission="load-bibliography"/>
         <xf:send submission="load-ensembles"/>
         <xf:send submission="load-instruments"/>


### PR DESCRIPTION
Fixes 
* Cannot add a new reference under Performance details
* Reviews tabs is missing reference types fields

How to test
* Log in, select a file and go to History tab
* Add a new performance and click on Edit performance button
* Under "Evidence" fieldset, select Add evidence
* You should be able to add a new bibliography item along with the entries in standard bibliography