### PR TITLE
fix internal links in XSL transformations

### DIFF
--- a/modules/present.xq
+++ b/modules/present.xq
@@ -27,7 +27,6 @@ return $doc
 
 let $params := 
 <parameters>
-   <param name="hostname" value="{$host}"/>#
    <param name="app-root" value="{$config:app-root}"/>
    <param name="data-root" value="{$config:data-root}"/>
    <param name="doc" value="{$document}"/>
@@ -42,4 +41,3 @@ if(request:get-parameter("debug","")) then
 (<d>{$params}{doc(concat($config:app-root,"/style/",$xsl))}</d>)
 else
 transform:transform($doc,doc(concat($config:app-root,"/style/",$xsl)),$params)
- 

--- a/style/config.xsl
+++ b/style/config.xsl
@@ -6,6 +6,8 @@
     exclude-result-prefixes="xs"
     version="2.0">
     
+    <xsl:param name="config:properties-path" as="xs:string" select="concat($app-root, '/properties.xml')"/>
+    
     <!--
         Return an absolute URL to the current MerMEId app for a given (relative) path 
         
@@ -14,8 +16,27 @@
     -->
     <xsl:function name="config:link-to-app" as="xs:string">
         <xsl:param name="relLink" as="xs:string?"/>
-        <xsl:param name="properties" as="element(dcm:properties)"/>
-        <xsl:value-of select="concat($properties//dcm:exist_endpoint, '/',  replace(normalize-space($relLink), '^/+', ''))"/>
+        <xsl:value-of select="concat(config:get-property('exist_endpoint'), '/',  replace(normalize-space($relLink), '^/+', ''))"/>
+    </xsl:function>
+    
+    <!--
+        Return the requested property value from the properties file
+        
+        @param $key the element to look for in the properties file
+        @return xs:string the option value as string identified by the key otherwise the empty sequence
+    -->
+    <xsl:function name="config:get-property" as="item()?">
+        <xsl:param name="key" as="xs:string?"/>
+        <xsl:variable name="properties" select="doc($config:properties-path)/dcm:properties"/>
+        <xsl:variable name="result" select="$properties/dcm:*[local-name() = $key]/node()"/>
+        <xsl:choose>
+            <xsl:when test="$result instance of text() or $result instance of xs:anyAtomicType">
+                <xsl:value-of select="normalize-space($result)"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:sequence select="$result[. instance of element()]"/>
+            </xsl:otherwise>
+        </xsl:choose>
     </xsl:function>
     
 </xsl:stylesheet>

--- a/style/config.xsl
+++ b/style/config.xsl
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:config="https://github.com/edirom/mermeid/config"
+    xmlns:dcm="http://www.kb.dk/dcm"
+    exclude-result-prefixes="xs"
+    version="2.0">
+    
+    <!--
+        Return an absolute URL to the current MerMEId app for a given (relative) path 
+        
+        @param $relLink the relative path within the app, e.g. "/data/incipit_demo.xml"
+        @return xs:string 
+    -->
+    <xsl:function name="config:link-to-app" as="xs:string">
+        <xsl:param name="relLink" as="xs:string?"/>
+        <xsl:param name="properties" as="element(dcm:properties)"/>
+        <xsl:value-of select="concat($properties//dcm:exist_endpoint, '/',  replace(normalize-space($relLink), '^/+', ''))"/>
+    </xsl:function>
+    
+</xsl:stylesheet>

--- a/style/mei_to_html.xsl
+++ b/style/mei_to_html.xsl
@@ -3,6 +3,7 @@
 	xmlns:foo="http://www.kb.dk/foo" xmlns:zs="http://www.loc.gov/zing/srw/" 
 	xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:m="http://www.music-encoding.org/ns/mei" 
 	xmlns:local="urn:my-stuff" xmlns:dcm="http://www.kb.dk/dcm" 
+	xmlns:config="https://github.com/edirom/mermeid/config"
 	version="2.0" exclude-result-prefixes="m xsl foo local">
 
 	<!-- 
@@ -16,11 +17,12 @@
 	-->
 	
 	<xsl:output method="xml" encoding="UTF-8" cdata-section-elements="" omit-xml-declaration="yes" indent="no" xml:space="default"/>
+	
+	<xsl:include href="common.xsl"/>
 
 	<xsl:strip-space elements="*"/>
 
 	<xsl:param name="doc"/>
-	<xsl:param name="hostname"/>
 	<xsl:param name="app-root"/>
 	<xsl:param name="data-root"/>
 	<xsl:param name="language"/>
@@ -600,7 +602,8 @@
 		<xsl:variable name="href">
 			<xsl:choose>
 				<xsl:when test="$mermeid_crossref='true'">
-					<xsl:value-of select="concat($settings/dcm:parameters/dcm:server_name,'/present.xq?doc=',@target)"/>
+					<!--<xsl:value-of select="concat($settings/dcm:parameters/dcm:server_name,'/present.xq?doc=',@target)"/>-->
+					<xsl:value-of select="config:link-to-app(concat('/modules/present.xq?doc=', @target), $settings)"/>
 				</xsl:when>
 				<xsl:otherwise>
 					<xsl:value-of select="@target"/>

--- a/style/mei_to_html.xsl
+++ b/style/mei_to_html.xsl
@@ -18,7 +18,7 @@
 	
 	<xsl:output method="xml" encoding="UTF-8" cdata-section-elements="" omit-xml-declaration="yes" indent="no" xml:space="default"/>
 	
-	<xsl:include href="common.xsl"/>
+	<xsl:include href="config.xsl"/>
 
 	<xsl:strip-space elements="*"/>
 

--- a/style/mei_to_html.xsl
+++ b/style/mei_to_html.xsl
@@ -44,9 +44,6 @@
 	
 	<!-- preferred language in titles and other multilingual fields -->
 	<xsl:variable name="preferred_language">none</xsl:variable>
-	<!-- general MerMEId settings -->
-	<xsl:variable name="settings"
-		select="document(concat($app-root, '/properties.xml'))"/>
 	<!-- file context - i.e. collection identifier like 'CNW' -->
 	<xsl:variable name="file_context">
 		<xsl:value-of select="/m:mei/m:meiHead/m:fileDesc/m:seriesStmt/m:identifier[@type='file_collection'][1]"/>
@@ -602,8 +599,7 @@
 		<xsl:variable name="href">
 			<xsl:choose>
 				<xsl:when test="$mermeid_crossref='true'">
-					<!--<xsl:value-of select="concat($settings/dcm:parameters/dcm:server_name,'/present.xq?doc=',@target)"/>-->
-					<xsl:value-of select="config:link-to-app(concat('/modules/present.xq?doc=', @target), $settings)"/>
+					<xsl:value-of select="config:link-to-app(concat('/modules/present.xq?doc=', @target))"/>
 				</xsl:when>
 				<xsl:otherwise>
 					<xsl:value-of select="@target"/>

--- a/style/mei_to_html_print_short.xsl
+++ b/style/mei_to_html_print_short.xsl
@@ -23,7 +23,8 @@
 	xmlns:exsl="http://exslt.org/common" 
 	xmlns:java="http://xml.apache.org/xalan/java"
 	xmlns:zs="http://www.loc.gov/zing/srw/" 
-	xmlns:marc="http://www.loc.gov/MARC21/slim" 
+	xmlns:marc="http://www.loc.gov/MARC21/slim"
+	xmlns:config="https://github.com/edirom/mermeid/config"
 	extension-element-prefixes="exsl java" 
 	exclude-result-prefixes="m xsl exsl foo java">
 	
@@ -107,7 +108,7 @@
 		<xsl:variable name="href">
 			<xsl:choose>
 				<xsl:when test="$mermeid_crossref='true'">
-					<xsl:value-of select="concat($settings/dcm:parameters/dcm:server_name,'/present.xq?doc=',@target)"/>
+					<xsl:value-of select="config:link-to-app(concat('/modules/present.xq?doc=', @target))"/>
 				</xsl:when>
 				<xsl:otherwise>
 					<xsl:value-of select="@target"/>
@@ -128,7 +129,7 @@
 		<xsl:if test="$mermeid_crossref='true'">
 			<!-- get collection name and number from linked files -->
 			<xsl:variable name="fileName"
-				select="concat($settings/dcm:parameters/dcm:server_name,$settings/dcm:parameters/dcm:document_root,@target)"/>
+				select="concat($data-root, '/', @target)"/>
 			<xsl:variable name="linkedDoc" select="document($fileName)"/>
 			<xsl:variable name="file_context"
 				select="$linkedDoc/m:mei/m:meiHead/m:fileDesc/m:seriesStmt/m:identifier[@type='file_collection']"/>


### PR DESCRIPTION
this is to fix #124 by adding a new `config` XSL module which features some functions we already developed for XQuery. Especially `config:link-to-app` which assures that internal links are resolved correctly.