### PR TITLE
add forms for <langUsage> in work, version information in music-tab, enable duplicate <desc> in performance

### DIFF
--- a/forms/details-performance.xml
+++ b/forms/details-performance.xml
@@ -130,22 +130,29 @@
                                 <h:div class="blocklabel strong">Contributors</h:div>
                                 <xi:include href="includes/person-input.xml"/>
                             </h:div>
+                    <h:br clear="all"/>
+                    <h:div class="blocklabel strong">Description <h:a class="help"> ?<h:span class="comment">
+                        An optional description of the event, e.g. "First performance in Denmark".</h:span>
+                    </h:a>
+                        <dcm:create nodeset="m:desc" label="Add description" origin="instance('empty-instance')/m:meiHead/m:workList/m:work/m:history/m:eventList[@type='performances']/m:event/m:desc"/>
+                        <xf:repeat nodeset="m:desc" id="performance-desc-repeat">
+                            <h:div class="vertical_spacer"/>
+                            <xf:input ref="@label" class="maxlong">
+                                <xf:label>
+                                    <h:span class="blocklabel">Label <h:a class="help"> ?<h:span class="comment">An optional label
+                                        for this block of text</h:span>
+                                    </h:a>
+                                    </h:span>
+                                </xf:label>
+                            </xf:input>
+                              <dcm:element-buttons triggers="up down add remove" nodeset="m:desc" index="performance-desc-repeat" origin="instance('empty-instance')/m:meiHead/m:workList/m:work/m:history/m:eventList[@type='performances']/m:event/m:desc"/>
+                            <dcm:id/>
+                            <dcm:attribute-editor/>
                             <h:br clear="all"/>
-                            <h:div class="blocklabel strong">Description <h:a class="help">&#160;?<h:span class="comment">
-                                An optional description of the event, e.g. "First performance in Denmark".</h:span></h:a></h:div>
-                            <dcm:create
-                                nodeset="m:desc"
-                                label="Add description"
-                                origin="instance('empty-instance')/m:meiHead/m:workList/m:work/m:history/m:eventList[@type='performances']/m:event/m:desc"/>
-                            <xf:repeat nodeset="m:desc" id="performance-desc-repeat">
-                                <h:div>
-                                    <fr:tinymce ref="."/>	
-                                    <dcm:element-buttons triggers="remove" nodeset="m:desc" index="performance-desc-repeat"
-                                        origin="instance('empty-instance')/m:meiHead/m:workList/m:work/m:history/m:eventList[@type='performances']/m:event/m:desc"/>
-                                    <dcm:attribute-editor/>
-                                </h:div>
-                            </xf:repeat>
-                            <h:br clear="all"/>
+                            <fr:tinymce ref="."/>
+                            <h:div class="vertical_spacer"/>
+                        </xf:repeat></h:div>
+                    <h:br clear="all"/>
                             <!-- single evidence reference using the event's "evidence" attribute (disabled)
                                 <xf:select1 ref="@evidence" class="maxlong">
                                 <xf:label class="fixed_width">Evidence <h:a class="help">&#160;?<h:span class="comment">Pointer to a bibliographic 

--- a/forms/main_form_music.xml
+++ b/forms/main_form_music.xml
@@ -258,6 +258,71 @@
 					</h:fieldset>
 					
 					
+					<!-- Version information -->
+					<h:fieldset>
+						<h:legend>Version information</h:legend>
+						<h:div class="vertical_spacer"/>
+						<dcm:create nodeset="m:notesStmt" label="Add version description" origin="instance('empty-instance')/m:meiHead/m:workList/m:work/m:expressionList/m:expression/m:notesStmt"/>
+						<xf:group ref="m:notesStmt">
+							<dcm:create nodeset="m:annot[@type='version_description']" label="Add version description" origin="instance('empty-instance')/m:meiHead/m:workList/m:work/m:notesStmt/m:annot[@type='version_description']"/>
+							<xf:group ref="m:annot[@type='version_description']">
+								<h:div class="blocklabel">Version description <h:a class="help"> ?<h:span class="comment">A description that refers to this specific version of the work</h:span>
+								</h:a>
+								</h:div>
+							</xf:group>
+							<xf:repeat nodeset="m:annot[@type='version_description']" id="repeat_version_description">
+								<xf:input ref="@label" class="maxlong">
+									<xf:label>
+										<h:span class="blocklabel">Label <h:a class="help"> ?<h:span class="comment">An optional label
+											for this block of text</h:span>
+										</h:a>
+										</h:span>
+									</xf:label>
+								</xf:input>  <dcm:element-buttons-typed triggers="add up down remove" index="repeat_version_description" nodeset="m:annot[@type='version_description']" origin="instance('empty-instance')/m:meiHead/m:workList/m:work/m:expressionList/m:expression/m:notesStmt/m:annot[@type='version_description']"/>
+								<dcm:id/>
+								<dcm:attribute-editor/>
+								<fr:tinymce ref="."/>
+								<h:hr/>
+							</xf:repeat>
+							
+							<h:div class="blocklabel">Links <h:a class="help"> ?<h:span class="comment">Links to external resources (web pages, PDF
+								files etc.) related to the version in general - not about a
+								particular source.									
+							</h:span>
+							</h:a>
+							</h:div>
+							<dcm:create nodeset="m:annot[@type='links']" label="Add link" origin="instance('empty-instance')/m:meiHead/m:workList/m:work/m:expressionList/m:expression/m:notesStmt/m:annot[@type='links']"/>
+							<dcm:create ref="m:annot[@type='links']" nodeset="m:ptr" label="Add link" origin="instance('empty-instance')/m:meiHead/m:workList/m:work/m:expressionList/m:expression/m:notesStmt/m:annot[@type='links']/m:ptr"/>
+							<xf:group ref="m:annot[@type='links']">
+								<xf:repeat nodeset="m:ptr" id="version-notesstmt-annot-repeat-ptr">
+									<h:div>
+										<xf:input ref="@target" class="long">
+											<xf:label>URI <h:a class="help"> ?<h:span class="comment">Link to the resource, e.g.
+												'http://example.com/preface.pdf'<br/>
+												MerMEId interprets references without the 'http://' protocol as links to other MEI files
+												in the same database as this one; for instance, 'sonata.xml' will be resolved as a link to 
+												a file of that name in the same folder in the database, 
+												whereas 'http://example.com/sonata.xml' generates a
+												link to an external web resource.
+											</h:span>
+											</h:a>
+											</xf:label>
+										</xf:input>
+										<xf:input ref="@label">
+											<xf:label>Label <h:a class="help"> ?<h:span class="comment">A short, descriptive text which
+												may serve as the link text, e.g. 'Printed edition's preface'</h:span>
+											</h:a>
+											</xf:label>
+										</xf:input>
+										<dcm:element-buttons triggers="up down copy add remove" nodeset="m:ptr" index="version-notesstmt-annot-repeat-ptr" origin="instance('empty-instance')/m:meiHead/m:workList/m:work/m:expressionList/m:expression/m:notesStmt/m:annot[@type='links']/m:ptr"/>
+										<dcm:attribute-editor ref="."/>
+									</h:div>
+								</xf:repeat>
+							</xf:group>
+						</xf:group>
+					</h:fieldset>
+					
+														
 					<!-- Relations -->
 					<h:fieldset>
 						<h:legend>Relations <h:a class="help">&#160;?<h:span class="comment">Relations between this version and 

--- a/forms/main_form_work.xml
+++ b/forms/main_form_work.xml
@@ -284,6 +284,26 @@
 
 			<xf:group ref="instance('data-instance')/m:meiHead/m:workList/m:work">
 				<h:fieldset>
+					<h:legend>Language <h:a class="help"> ?<h:span class="comment">The langUsage element is used within the workList element to describe the languages, sublanguages, dialects, etc. represented within a work.<h:br/> It contains one or more language elements, each of which provides information about a single language.</h:span>
+					</h:a>
+					</h:legend>
+					<dcm:create nodeset="m:langUsage" label="Add language" origin="instance('empty-instance')/m:meiHead/m:workList/m:work/m:langUsage"/>
+					
+					<dcm:create ref="m:langUsage" nodeset="m:language" label="Add language" origin="instance('empty-instance')/m:meiHead/m:workList/m:work/m:langUsage/m:language"/>
+					
+					<xf:repeat nodeset="instance('data-instance')/m:meiHead/m:workList/m:work/m:langUsage/m:language" id="work-lang-repeat">
+						<h:div>
+							<h:span>Language </h:span>  
+							<xi:include href="includes/input_with_xmllang.xml" parse="xml"/>
+							<dcm:element-buttons triggers="add remove up down" nodeset="m:language" index="work-lang-repeat" origin="instance('empty-instance')/m:meiHead/m:workList/m:work/m:langUsage/m:language"/>
+							<dcm:attribute-editor ref="."/>
+						</h:div>
+					</xf:repeat>
+				</h:fieldset>
+			</xf:group>
+
+			<xf:group ref="instance('data-instance')/m:meiHead/m:workList/m:work">
+				<h:fieldset>
 					<h:legend>Relations <h:a class="help">&#160;?<h:span class="comment">Relations
 								between this work and other works or files may be specified here to
 								create links between them.<h:br/> For instance, if this work is also

--- a/forms/model/empty_doc.xml
+++ b/forms/model/empty_doc.xml
@@ -256,7 +256,10 @@
                   <perfDuration/>
                   <extent unit=""/>
                   <notesStmt>
-                     <annot/>
+                     <annot type="links">
+                        <ptr target="" mimetype="" label=""/>
+                     </annot>
+                     <annot type="version_description" label=""/>
                   </notesStmt>
                   <classification>
                      <termList>

--- a/forms/model/empty_doc.xml
+++ b/forms/model/empty_doc.xml
@@ -116,7 +116,7 @@
                </eventList>
             </history>
             <langUsage>
-               <language xml:id="en">English</language>
+               <language xml:id="" xml:lang=""></language>
             </langUsage>
             <biblList>
                <head>Bibliography</head>

--- a/forms/model/empty_doc.xml
+++ b/forms/model/empty_doc.xml
@@ -90,7 +90,7 @@
                      <corpName role="ensemble"/>
                      <persName role="conductor"/>
                      <corpName role=""/>
-                     <desc/>
+                     <desc label=""/>
                      <biblList>
                         <head>Reviews</head>
                         <bibl label="">
@@ -208,7 +208,7 @@
                            <geogName role="place"/>
                            <corpName role="ensemble"/>
                            <persName role="conductor"/>
-                           <desc/>
+                           <desc label=""/>
                            <biblList>
                               <head>Reviews</head>
                               <bibl label="">

--- a/forms/model/new_file.xml
+++ b/forms/model/new_file.xml
@@ -64,7 +64,7 @@
                <p/>
             </history>
             <langUsage>
-               <language xml:id="en">English</language>
+               <language xml:id="" xml:lang=""></language>
             </langUsage>
             <expressionList>
                <expression n="">


### PR DESCRIPTION
add forms for lang Usage in general workdescription, remove "English" as default in empty_docs and new_file