### PR TITLE
fix HTML output of timeline descriptions

### DIFF
--- a/style/mei_to_html.css
+++ b/style/mei_to_html.css
@@ -538,3 +538,7 @@ a:hover.help span.comment {
     }
 
 }
+
+.history.timeline p:first-child {
+    margin-top: 0px;
+}

--- a/style/mei_to_html.xsl
+++ b/style/mei_to_html.xsl
@@ -1643,7 +1643,7 @@
 					<xsl:text>). </xsl:text>
 				</xsl:if>				
 
-				<xsl:for-each select="m:desc[text()]">
+				<xsl:for-each select="m:desc[.//text()]">
 					<xsl:apply-templates/>
 					<xsl:text> </xsl:text>
 				</xsl:for-each>

--- a/style/mei_to_html.xsl
+++ b/style/mei_to_html.xsl
@@ -1535,7 +1535,7 @@
 
 		<!-- history time line -->
 		<xsl:for-each select="m:eventList[@type='history' and m:event[//text()]]">
-			<table>
+			<table class="history timeline">
 				<xsl:for-each select="m:event[//text()]">
 					<xsl:apply-templates select="." mode="performance_details"/>
 				</xsl:for-each>


### PR DESCRIPTION
This PR fixes #168 by updating an XPath predicate to recursively look for text nodes within an `<mei:desc>`.  NB, there's a related issue (that surfaced here) in that the MerMEId creates invalid MEI by adding an `<mei:p>` within `<mei:desc>`. Yet, I think the proposed fix is still valid since there are other child elements allowed within `<mei:desc>` that also might fool the original XPath expression.