### PR TITLE
remove caching, fixes #176

### DIFF
--- a/data/controller.xql
+++ b/data/controller.xql
@@ -209,7 +209,7 @@ else
 (: everything else is passed through :)
    (console:log('/data Controller: passthrough'),
     <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
-        <cache-control cache="yes"/>
+        <cache-control cache="no"/>
         <set-attribute name="$exist:prefix" value="{$exist:prefix}"/>
         <set-attribute name="$exist:controller" value="{$exist:controller}"/>
         <set-attribute name="$exist:root" value="{$exist:root}"/>


### PR DESCRIPTION
The caching was blocking further requests for different HTTP methods. So, once an e.g. OPTIONS request was cached with a 404, subsequent calls to the same endpoint but via GET where hitting the 404 as well