### PR TITLE
update test dependencies

### DIFF
--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -16,7 +16,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>5.1.0</version>
+            <version>5.6.2</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-java</artifactId>
-            <version>4.9.0</version>
+            <version>4.15.0</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
this PR updates Selenium and Webdrivermanager to fix the current issue of failing tests with error message "Could not start a new session. Response code 500. Message: session not created: This version of ChromeDriver only supports Chrome version 114"