### PR TITLE
Fix merge xquery

### DIFF
--- a/modules/merge/merge.xq
+++ b/modules/merge/merge.xq
@@ -57,6 +57,8 @@ let $params :=
    <param name="hostname" value="{request:get-header('HOST')}"/>
    <param name="language" value="{$language}"/>
    <param name="score" value="{$score}"/>
+   <param name="app-root" value="{$config:app-root}"/>
+   <param name="data-root" value="{$config:data-root}"/>
 </parameters>
 
 let $list := loop:getlist($database,$coll,$genre,$query)

--- a/modules/merge/merge_settings.xq
+++ b/modules/merge/merge_settings.xq
@@ -50,7 +50,7 @@ let $formpage :=
 	      <input type="text" value="{$query}" name="query" style="width: 30em;"/><br/>&#160; 
 	      </p>
 	      <p><strong>eXist database</strong><br/>
-	      The collection /db/apps/mermeid/data/ is where MerMEId stores your files by default. /db/apps/mermeid/data-public/ usually 
+	      The collection {$database} is where MerMEId stores your files by default. {$database} usually 
 	      contains the files you have published with MerMEId.<br/>
 	      <input type="text" value="{$database}" name="db" style="width: 30em;"/><br/>&#160; 
 	      </p>

--- a/style/mei_to_html.xsl
+++ b/style/mei_to_html.xsl
@@ -22,7 +22,6 @@
 
 	<xsl:strip-space elements="*"/>
 
-	<xsl:param name="doc"/>
 	<xsl:param name="app-root"/>
 	<xsl:param name="data-root"/>
 	<xsl:param name="language"/>


### PR DESCRIPTION
this PR fixes the XQuery `merge.xq` "Merge multiple HTML documents"  from the tools section (see https://github.com/Edirom/MerMEId/issues/181#issuecomment-1845282700)

Additionally, I removed one unused parameter and used the variable `$database` for the description text, not only for the placeholder. 