### PR TITLE
Minor fixes and additions in manual pages; updated footers for manual pages (part of #181)

### DIFF
--- a/manual/attribute_editor.html
+++ b/manual/attribute_editor.html
@@ -57,11 +57,9 @@
         not available for all elements in use. To access all elements and their attributes, use
         other tools like a generic XML or text editor.</p>
     </div>
-
-    <p class="footer"><a href="http://www.kb.dk" title="DCM"><img
-          style="border: 0px; vertical-align:middle;" alt="DCM Logo"
-          src="../resources/images/dcm_logo_small_white.png" /></a> 2017 Danish Centre for Music Editing |
-      Royal Danish Library, Copenhagen | <a name="www.kb.dk" id="www.kb.dk"
-        href="http://www.kb.dk">www.kb.dk</a></p>
+    <div class="footer">
+      <div>2010-2019 Danish Centre for Music Editing | Royal Danish Library, Copenhagen | <a name="https://www.kb.dk/" id="www.kb.dk" href="http://www.kb.dk" title="Det Kgl. Bibliotek">www.kb.dk</a></div>
+      <div>2020 ff. <a href="https://github.com/Edirom/MerMEId/graphs/contributors" title="See contributors to MerMEId GitHub project"> MerMEId Community</a></div>     
+    </div>
   </body>
 </html>

--- a/manual/basics.html
+++ b/manual/basics.html
@@ -180,9 +180,9 @@
       <p>At the bottom of the page, in grey, metadata about the file
         are displayed (i.e. the colophon).</p>
     </div>
-    <p class="footer"><a href="http://www.kb.dk" title="DCM"><img style="border: 0px; vertical-align:middle;" 
-      alt="DCM Logo" src="../resources/images/dcm_logo_small_white.png"/></a> 
-      2017 Danish Centre for Music Editing | Royal Danish Library,
-      Copenhagen | <a name="www.kb.dk" id="www.kb.dk" href="http://www.kb.dk">www.kb.dk/en/nb/dcm</a></p>
+    <div class="footer">
+      <div>2010-2019 Danish Centre for Music Editing | Royal Danish Library, Copenhagen | <a name="https://www.kb.dk/" id="www.kb.dk" href="http://www.kb.dk" title="Det Kgl. Bibliotek">www.kb.dk</a></div>
+      <div>2020 ff. <a href="https://github.com/Edirom/MerMEId/graphs/contributors" title="See contributors to MerMEId GitHub project"> MerMEId Community</a></div>     
+    </div>
   </body>
 </html>

--- a/manual/basics.html
+++ b/manual/basics.html
@@ -19,17 +19,17 @@
       <h2><a name="basics" id="basics">MerMEId
         basics</a></h2>
       <p>MerMEId (Metadata Editor and Repository for MEI data) is a
-        tool for editing, (pre-)viewing and handling of music metadata based on
-        <a href="http://www.music-encoding.org" target="_blank" title="Music Encoding Initiative">MEI</a>. </p>
+        tool for editing, (pre-)viewing and handling <a href="http://www.music-encoding.org" target="_blank" title="Music Encoding Initiative">MEI</a> metadata.</p>
       <p>The user interface has three main components: the MEI file browser,
         the metadata editing tool, and the HTML preview. </p>
       <h3><a name="File" id="File">Document list</a></h3>
       <p>The usual way to start working with MerMEId would be to open
-        the document list, usually located at <a href="../modules/list_files.xq" target="_blank"
+        the document list, usually located at <a href="../index.html" target="_blank"
           title="Go to the document list on this server">http://[your hostname
-          here]/modules/list_files.xq</a>. You should then see a list
+          here]/index.html</a>. You should then see a list
         of existing documents in your collection (if any):</p>
       <p><img alt="" src="../resources/images/manual/list_files.png" class="illustration"/></p>
+      <p>Please note that you need to <strong>Login</strong> ("mermeid" // "mermeid" are the demo credentials) at the top right corner of the page to be able to edit documents or make changes of any kind.</p>
       <p><strong>Creating a new document: </strong>To create a new document, click the add
         button <img alt="New file" src="../resources/images/new.gif" height="16" width="16"/> located in the upper right corner.  
         This will open a new document in the metadata editor.</p>

--- a/manual/batch_transform.html
+++ b/manual/batch_transform.html
@@ -71,10 +71,9 @@
                 result page will list the files changed and those that were unaffected by the
                 transformation.</p>
         </div>
-        <p class="footer"><a href="http://www.kb.dk" title="DCM"><img
-                    style="border: 0px; vertical-align:middle;" alt="DCM Logo"
-                    src="../resources/images/dcm_logo_small_white.png" /></a> 2017 Danish Centre for Music
-            Editing | Royal Danish Library, Copenhagen | <a name="www.kb.dk" id="www.kb.dk"
-                href="http://www.kb.dk">www.kb.dk/en/nb/dcm</a></p>
-    </body>
+    <div class="footer">
+      <div>2010-2019 Danish Centre for Music Editing | Royal Danish Library, Copenhagen | <a name="https://www.kb.dk/" id="www.kb.dk" href="http://www.kb.dk" title="Det Kgl. Bibliotek">www.kb.dk</a></div>
+      <div>2020 ff. <a href="https://github.com/Edirom/MerMEId/graphs/contributors" title="See contributors to MerMEId GitHub project"> MerMEId Community</a></div>     
+    </div>
+  </body>
 </html>

--- a/manual/code_inspector.html
+++ b/manual/code_inspector.html
@@ -54,10 +54,9 @@
                     formatting into HTML markup on loading – and vice versa on saving.</li>
             </ul>
         </div>
-        <p class="footer"><a href="http://www.kb.dk" title="DCM"><img
-                    style="border: 0px; vertical-align:middle;" alt="DCM Logo"
-                    src="../resources/images/dcm_logo_small_white.png" /></a> 2017 Danish Centre for Music
-            Editing | Royal Danish Library, Copenhagen | <a name="www.kb.dk" id="www.kb.dk"
-                href="http://www.kb.dk">www.kb.dk/en/nb/dcm</a></p>
-    </body>
+    <div class="footer">
+      <div>2010-2019 Danish Centre for Music Editing | Royal Danish Library, Copenhagen | <a name="https://www.kb.dk/" id="www.kb.dk" href="http://www.kb.dk" title="Det Kgl. Bibliotek">www.kb.dk</a></div>
+      <div>2020 ff. <a href="https://github.com/Edirom/MerMEId/graphs/contributors" title="See contributors to MerMEId GitHub project"> MerMEId Community</a></div>     
+    </div>
+  </body>
 </html>

--- a/manual/dates.html
+++ b/manual/dates.html
@@ -48,10 +48,9 @@
         changing the original date. When the date editor closes, the machine-readable part will be
         displayed on the main form in square brackets.</p>
     </div>
-    <p class="footer"><a href="http://www.kb.dk" title="DCM"><img
-          style="border: 0px; vertical-align:middle;" alt="DCM Logo"
-          src="../resources/images/dcm_logo_small_white.png" /></a> 2017 Danish Centre for Music Editing |
-      Royal Danish Library, Copenhagen | <a name="www.kb.dk" id="www.kb.dk"
-        href="http://www.kb.dk">www.kb.dk/en/nb/dcm</a></p>
+    <div class="footer">
+      <div>2010-2019 Danish Centre for Music Editing | Royal Danish Library, Copenhagen | <a name="https://www.kb.dk/" id="www.kb.dk" href="http://www.kb.dk" title="Det Kgl. Bibliotek">www.kb.dk</a></div>
+      <div>2020 ff. <a href="https://github.com/Edirom/MerMEId/graphs/contributors" title="See contributors to MerMEId GitHub project"> MerMEId Community</a></div>     
+    </div>
   </body>
 </html>

--- a/manual/document_structure.html
+++ b/manual/document_structure.html
@@ -215,10 +215,9 @@
                 of the catalogue or project) which MerMEId uses to organize files into different
                 catalogues/projects.</p>
         </div>
-        <p class="footer"><a href="http://www.kb.dk" title="DCM"><img
-                    style="border: 0px; vertical-align:middle;" alt="DCM Logo"
-                    src="../resources/images/dcm_logo_small_white.png" /></a> 2017 Danish Centre for Music
-            Editing | Royal Danish Library, Copenhagen | <a name="www.kb.dk" id="www.kb.dk"
-                href="http://www.kb.dk">www.kb.dk/en/nb/dcm</a></p>
-    </body>
+    <div class="footer">
+      <div>2010-2019 Danish Centre for Music Editing | Royal Danish Library, Copenhagen | <a name="https://www.kb.dk/" id="www.kb.dk" href="http://www.kb.dk" title="Det Kgl. Bibliotek">www.kb.dk</a></div>
+      <div>2020 ff. <a href="https://github.com/Edirom/MerMEId/graphs/contributors" title="See contributors to MerMEId GitHub project"> MerMEId Community</a></div>     
+    </div>
+  </body>
 </html>

--- a/manual/document_structure.html
+++ b/manual/document_structure.html
@@ -98,7 +98,7 @@
                 version is created. </p>
             <p>See also the tutorial: <a href="../manual/tutorial_versions.html"
                     title="Tutorial: Works having multiple versions">Works having multiple
-                    version</a></p>
+                    versions</a></p>
             <p><span class="heading">Movements:</span> The movements of a work are encoded as
                 components of a version. They are defined at the bottom of each 'version' block at
                 the <span class="music tab">Music</span> tab. MerMEId calls them 'components' rather
@@ -141,10 +141,10 @@
                 particular edition and therefore should be entered at source level.</p>
             <p>The distinction between sources and items may seem particularly confusing when
                 describing manuscript sources which obviously are unique. However, the same encoding
-                pratice should be applied to manuscripts and prints to ensure the same
+                practice should be applied to manuscripts and prints to ensure the same
                 functionality; thinking of manuscripts as printed sources with only one surviving
                 copy may be helpful when deciding where to enter what information.</p>
-            <p>To minimize redundancy no information given at source level should be repeated at
+            <p>To minimize redundancy, no information given at source level should be repeated at
                 item level. As a rule of thumb, we recommend putting information at the highest
                 possible level. For instance, the title page of a manuscript should be cited at
                 source level rather than at item level. The description of other features like paper
@@ -158,7 +158,7 @@
                 versions they embody (see also the tutorial: <a
                     href="../manual/tutorial_versions.html"
                     title="Tutorial: Works having multiple versions">Works having multiple
-                    version</a>). </p>
+                    versions</a>). </p>
             <h3>Source components</h3>
             <p>Both sources and items can have components to be described indivdually. For example,
                 a set of orchestral parts can be defined as a source with some shared features (such
@@ -194,7 +194,7 @@
                 either work or version level. See also the tutorial: <a
                     href="../manual/tutorial_versions.html"
                     title="Tutorial: Works having multiple versions">Works having multiple
-                    version</a></p>
+                    versions</a></p>
             <h2>Bibliographic references</h2>
             <p>The <span class="bibliography tab">Bibliography</span> tab allows the user to add a
                 list of other material related to the musical work but not regarded as sources to
@@ -209,7 +209,7 @@
             <p>These metadata include information about the persons, institutions, and software
                 involved in the creation of the file. Also a project description and a note aboout
                 use restrictions - such as copyright or license information - may be given. </p>
-            <p>Technical/adminsitrative metadata are edited at the <span class="file tab"
+            <p>Technical/administrative metadata are edited at the <span class="file tab"
                     >File</span> tab.</p>
             <p>File metadata also include the name of the 'file collection' (usually the short name
                 of the catalogue or project) which MerMEId uses to organize files into different

--- a/manual/faq.html
+++ b/manual/faq.html
@@ -391,10 +391,9 @@
           target="_blank">web site</a>.</p>
     </div>
 
-    <p class="footer"><a href="http://www.kb.dk" title="DCM"><img
-          style="border: 0px; vertical-align:middle;" alt="DCM Logo"
-          src="../resources/images/dcm_logo_small_white.png" /></a> 2017 Danish Centre for Music Editing |
-      Royal Danish Library, Copenhagen | <a name="www.kb.dk" id="www.kb.dk"
-        href="http://www.kb.dk">www.kb.dk/en/nb/dcm</a></p>
+    <div class="footer">
+      <div>2010-2019 Danish Centre for Music Editing | Royal Danish Library, Copenhagen | <a name="https://www.kb.dk/" id="www.kb.dk" href="http://www.kb.dk" title="Det Kgl. Bibliotek">www.kb.dk</a></div>
+      <div>2020 ff. <a href="https://github.com/Edirom/MerMEId/graphs/contributors" title="See contributors to MerMEId GitHub project"> MerMEId Community</a></div>     
+    </div>
   </body>
 </html>

--- a/manual/index.html
+++ b/manual/index.html
@@ -49,10 +49,9 @@
       </ul>
     </div>
 
-    <p class="footer"><a href="http://www.kb.dk" title="DCM"><img
-          style="border: 0px; vertical-align:middle;" alt="DCM Logo"
-          src="../resources/images/dcm_logo_small_white.png" /></a> 2017 Danish Centre for Music Editing |
-      Royal Danish Library, Copenhagen | <a name="www.kb.dk" id="www.kb.dk"
-        href="http://www.kb.dk">www.kb.dk/en/nb/dcm</a></p>
+    <div class="footer">
+      <div>2010-2019 Danish Centre for Music Editing | Royal Danish Library, Copenhagen | <a name="https://www.kb.dk/" id="www.kb.dk" href="http://www.kb.dk" title="Det Kgl. Bibliotek">www.kb.dk</a></div>
+      <div>2020 ff. <a href="https://github.com/Edirom/MerMEId/graphs/contributors" title="See contributors to MerMEId GitHub project"> MerMEId Community</a></div>     
+    </div>
   </body>
 </html>

--- a/manual/index_tools.html
+++ b/manual/index_tools.html
@@ -104,10 +104,9 @@
             <h3>Generating drop-down lists for online catalogues</h3>
             <p>[To be added]</p>-->
         </div>
-        <p class="footer"><a href="http://www.kb.dk" title="DCM"><img
-                    style="border: 0px; vertical-align:middle;" alt="DCM Logo"
-                    src="../resources/images/dcm_logo_small_white.png" /></a> 2017 Danish Centre for Music
-            Editing | Royal Danish Library, Copenhagen | <a name="www.kb.dk" id="www.kb.dk"
-                href="http://www.kb.dk">www.kb.dk/en/nb/dcm</a></p>
-    </body>
+    <div class="footer">
+      <div>2010-2019 Danish Centre for Music Editing | Royal Danish Library, Copenhagen | <a name="https://www.kb.dk/" id="www.kb.dk" href="http://www.kb.dk" title="Det Kgl. Bibliotek">www.kb.dk</a></div>
+      <div>2020 ff. <a href="https://github.com/Edirom/MerMEId/graphs/contributors" title="See contributors to MerMEId GitHub project"> MerMEId Community</a></div>     
+    </div>
+  </body>
 </html>

--- a/manual/merge.html
+++ b/manual/merge.html
@@ -35,10 +35,9 @@
                 (http://[your-server]/storage/style/) is referring to the collection /db/mermeid/style/ in your eXist database, 
                 but your style sheet may also be located outside of the database or on some other server</p>
         </div>
-        <p class="footer"><a href="http://www.kb.dk" title="DCM"><img
-                    style="border: 0px; vertical-align:middle;" alt="DCM Logo"
-                    src="../resources/images/dcm_logo_small_white.png" /></a> 2017 Danish Centre for Music
-            Editing | Royal Danish Library, Copenhagen | <a name="www.kb.dk" id="www.kb.dk"
-                href="http://www.kb.dk">www.kb.dk/en/nb/dcm</a></p>
-    </body>
+    <div class="footer">
+      <div>2010-2019 Danish Centre for Music Editing | Royal Danish Library, Copenhagen | <a name="https://www.kb.dk/" id="www.kb.dk" href="http://www.kb.dk" title="Det Kgl. Bibliotek">www.kb.dk</a></div>
+      <div>2020 ff. <a href="https://github.com/Edirom/MerMEId/graphs/contributors" title="See contributors to MerMEId GitHub project"> MerMEId Community</a></div>     
+    </div>
+  </body>
 </html>

--- a/manual/special_characters.html
+++ b/manual/special_characters.html
@@ -342,10 +342,9 @@
         </tbody>
       </table>
     </div>
-    <p class="footer"><a href="http://www.kb.dk" title="DCM"><img
-          style="border: 0px; vertical-align:middle;" alt="DCM Logo"
-          src="../resources/images/dcm_logo_small_white.png" /></a> 2017 Danish Centre for Music Editing |
-      Royal Danish Library, Copenhagen | <a name="www.kb.dk" id="www.kb.dk"
-        href="http://www.kb.dk">www.kb.dk/en/nb/dcm</a></p>
+    <div class="footer">
+      <div>2010-2019 Danish Centre for Music Editing | Royal Danish Library, Copenhagen | <a name="https://www.kb.dk/" id="www.kb.dk" href="http://www.kb.dk" title="Det Kgl. Bibliotek">www.kb.dk</a></div>
+      <div>2020 ff. <a href="https://github.com/Edirom/MerMEId/graphs/contributors" title="See contributors to MerMEId GitHub project"> MerMEId Community</a></div>     
+    </div>
   </body>
 </html>

--- a/manual/tutorial_anthology.html
+++ b/manual/tutorial_anthology.html
@@ -73,8 +73,9 @@
       <p><img src="../resources/images/manual/anthology_html.png" alt="work-to-work relations"
           class="illustration" /></p>
     </div>
-    <p class="footer"><a href="http://www.kb.dk" title="DCM"><img style="border: 0px; vertical-align:middle;" alt="DCM Logo" src="../resources/images/dcm_logo_small_white.png"/></a> 
-      2017 Danish Centre for Music Editing | Royal Danish Library,
-      Copenhagen | <a name="www.kb.dk" id="www.kb.dk" href="http://www.kb.dk">www.kb.dk/en/nb/dcm</a></p>
+    <div class="footer">
+      <div>2010-2019 Danish Centre for Music Editing | Royal Danish Library, Copenhagen | <a name="https://www.kb.dk/" id="www.kb.dk" href="http://www.kb.dk" title="Det Kgl. Bibliotek">www.kb.dk</a></div>
+      <div>2020 ff. <a href="https://github.com/Edirom/MerMEId/graphs/contributors" title="See contributors to MerMEId GitHub project"> MerMEId Community</a></div>     
+    </div>
   </body>
 </html>

--- a/manual/tutorial_bibliography.html
+++ b/manual/tutorial_bibliography.html
@@ -86,8 +86,9 @@
                     the reference.</li>
             </ul>
         </div>
-        <p class="footer"><a href="http://www.kb.dk" title="DCM"><img style="border: 0px; vertical-align:middle;" alt="DCM Logo" src="../resources/images/dcm_logo_small_white.png"/></a> 
-            2017 Danish Centre for Music Editing | Royal Danish Library,
-            Copenhagen | <a name="www.kb.dk" id="www.kb.dk" href="http://www.kb.dk">www.kb.dk/en/nb/dcm</a></p>
-    </body>
+    <div class="footer">
+      <div>2010-2019 Danish Centre for Music Editing | Royal Danish Library, Copenhagen | <a name="https://www.kb.dk/" id="www.kb.dk" href="http://www.kb.dk" title="Det Kgl. Bibliotek">www.kb.dk</a></div>
+      <div>2020 ff. <a href="https://github.com/Edirom/MerMEId/graphs/contributors" title="See contributors to MerMEId GitHub project"> MerMEId Community</a></div>     
+    </div>
+  </body>
 </html>

--- a/manual/tutorial_external_sources.html
+++ b/manual/tutorial_external_sources.html
@@ -80,7 +80,9 @@
       from the source adding menu. This places an independent copy of the external source description in your 
       current file, which can be freely edited.</p>
     </div>
-    <p class="footer"><a href="http://www.kb.dk" title="DCM"><img style="border: 0px; vertical-align:middle;" alt="DCM Logo" src="../resources/images/dcm_logo_small_white.png"/></a> 
-      2017 Danish Centre for Music Editing | Royal Danish Library,
-      Copenhagen | <a name="www.kb.dk" id="www.kb.dk" href="http://www.kb.dk">www.kb.dk/en/nb/dcm</a></p>
-  </body></html>
+    <div class="footer">
+      <div>2010-2019 Danish Centre for Music Editing | Royal Danish Library, Copenhagen | <a name="https://www.kb.dk/" id="www.kb.dk" href="http://www.kb.dk" title="Det Kgl. Bibliotek">www.kb.dk</a></div>
+      <div>2020 ff. <a href="https://github.com/Edirom/MerMEId/graphs/contributors" title="See contributors to MerMEId GitHub project"> MerMEId Community</a></div>     
+    </div>
+  </body>
+</html>

--- a/manual/tutorial_reprint.html
+++ b/manual/tutorial_reprint.html
@@ -48,10 +48,9 @@
         select the reprint source as its target. Note, however, that this reverse relation has no
         visible effect in MerMEId.</p>
     </div>
-    <p class="footer"><a href="http://www.kb.dk" title="DCM"><img
-          style="border: 0px; vertical-align:middle;" alt="DCM Logo"
-          src="../resources/images/dcm_logo_small_white.png" /></a> 2017 Danish Centre for Music Editing |
-      Royal Danish Library, Copenhagen | <a name="www.kb.dk" id="www.kb.dk"
-        href="http://www.kb.dk">www.kb.dk/en/nb/dcm</a></p>
+    <div class="footer">
+      <div>2010-2019 Danish Centre for Music Editing | Royal Danish Library, Copenhagen | <a name="https://www.kb.dk/" id="www.kb.dk" href="http://www.kb.dk" title="Det Kgl. Bibliotek">www.kb.dk</a></div>
+      <div>2020 ff. <a href="https://github.com/Edirom/MerMEId/graphs/contributors" title="See contributors to MerMEId GitHub project"> MerMEId Community</a></div>     
+    </div>
   </body>
 </html>

--- a/manual/tutorial_versions.html
+++ b/manual/tutorial_versions.html
@@ -49,8 +49,9 @@
                 </li>
             </ul>
         </div>
-        <p class="footer"><a href="http://www.kb.dk" title="DCM"><img style="border: 0px; vertical-align:middle;" alt="DCM Logo" src="../resources/images/dcm_logo_small_white.png"/></a> 
-            2017 Danish Centre for Music Editing | Royal Danish Library,
-            Copenhagen | <a name="www.kb.dk" id="www.kb.dk" href="http://www.kb.dk">www.kb.dk/en/nb/dcm</a></p>
-    </body>
+    <div class="footer">
+      <div>2010-2019 Danish Centre for Music Editing | Royal Danish Library, Copenhagen | <a name="https://www.kb.dk/" id="www.kb.dk" href="http://www.kb.dk" title="Det Kgl. Bibliotek">www.kb.dk</a></div>
+      <div>2020 ff. <a href="https://github.com/Edirom/MerMEId/graphs/contributors" title="See contributors to MerMEId GitHub project"> MerMEId Community</a></div>     
+    </div>
+  </body>
 </html>

--- a/manual/workflow.html
+++ b/manual/workflow.html
@@ -114,8 +114,9 @@
             into InDesign for the final layout. A more elegant way would be to write a transformation from MEI to 
                 <a href="https://www.latex-project.org/" title="LaTeX" target="_blank">LaTeX</a>, for instance.</p>
         </div>
-        <p class="footer"><a href="http://www.kb.dk" title="DCM"><img style="border: 0px; vertical-align:middle;" alt="DCM Logo" src="../resources/images/dcm_logo_small_white.png"/></a> 
-            2017 Danish Centre for Music Editing | Royal Danish Library,
-            Copenhagen | <a name="www.kb.dk" id="www.kb.dk" href="http://www.kb.dk">www.kb.dk/en/nb/dcm</a></p>
-    </body>
+    <div class="footer">
+      <div>2010-2019 Danish Centre for Music Editing | Royal Danish Library, Copenhagen | <a name="https://www.kb.dk/" id="www.kb.dk" href="http://www.kb.dk" title="Det Kgl. Bibliotek">www.kb.dk</a></div>
+      <div>2020 ff. <a href="https://github.com/Edirom/MerMEId/graphs/contributors" title="See contributors to MerMEId GitHub project"> MerMEId Community</a></div>     
+    </div>
+  </body>
 </html>

--- a/manual/workflow.html
+++ b/manual/workflow.html
@@ -34,7 +34,7 @@
             <p>This page described a workflow intended to make working with MerMEId as efficient as possible.</p>
             
             <p>MerMEId is designed for editing and storing metadata in MEI files; usually each file describes one musical work. 
-                The list shown when <a href="../modules/list_files.xq" title="MerMEId file list">entering
+                The list shown when <a href="../index.html" title="MerMEId file list">entering
             MerMEId</a> is basically a list of the MEI files stored in the database at any time.</p>
             <p>Assuming that you want to create a number of files all belonging to the same project or catalogue, 
                 we recommend the following workflow for creating the files and entering the data.</p>
@@ -95,7 +95,7 @@
             </ul>
             <h2>Content editing</h2>
             <ul>
-                <li>Add any data you want to the file (see <a href="../manual/">tutorials and other help pages</a>
+                <li>Add any data you want to the file (see <a href="../manual/index.html">tutorials and other help pages</a>
                     on how to use the editor and how to enter certain types of information).</li>
                 <li>To verify or proofread your data, use the HTML preview by clicking the document button <img alt="HTML preview" 
                     src="../resources/images/html.gif" /> to generate a human-readable HTML page from the file.</li>
@@ -106,12 +106,10 @@
             potentially very large, HTML document.</p>
             <p>The use of the tool is explained in the manual's section on <a title="Displaying multiple records" 
                 href="../manual/merge.html">Displaying or printing multiple (or all) records</a>.</p>
-            <p>By default, MerMEId will output the almost the same way as in the HTML preview only improved for printing 
-            (by unfolding all hidden sections, for instance), but you can specify another XSL transformation to customize the 
-            results for your needs. </p>
-            <p>The remaining steps to prepare a print catalogue are up to you. For the <a title="Printed CNW" target="_blank" 
-                href="https://www.mtp.dk/langset.asp?sitelan=e&amp;url=https://www.mtp.dk/details.asp?eln=203742">printed 
-                catalogue of Carl Nielsen's works</a>,
+            <p>By default, the output will be almost the same as in the HTML preview, but improved for printing 
+            (by unfolding all hidden sections, for example), but you can specify another XSL transformation to customize the 
+            results for your needs.</p>
+            <p>The remaining steps to prepare a print catalogue are up to you. For the printed catalogue of Carl Nielsen's works,
             we chose a quick but dirty approach: we simply copied the resulting HTML into a Word document which was imported 
             into InDesign for the final layout. A more elegant way would be to write a transformation from MEI to 
                 <a href="https://www.latex-project.org/" title="LaTeX" target="_blank">LaTeX</a>, for instance.</p>


### PR DESCRIPTION
Minor fixes (e.g. typos) and additions in:
+ `manual/document_structure.html`
+ `manual/workflow.html`
+ `manual/basics.html`

Manual pages footer updated to look like this:
![Screenshot from 2024-01-17 15-18-24](https://github.com/Edirom/MerMEId/assets/20640716/0088bf30-0a09-45de-baf0-ee6aacc78025)
