### PR TITLE
commented out: using standard bibliographies

### DIFF
--- a/manual/index.html
+++ b/manual/index.html
@@ -41,7 +41,8 @@
         <li><a href="tutorial_reprint.html">Adding a reprint edition to a source</a></li>
         <li><a href="tutorial_external_sources.html">Using external sources – linking to and copying
             from sources in other files</a></li>
-        <li><a href="tutorial_bibliography.html">Using standard bibliographies</a></li>
+        <!--<li><a href="tutorial_bibliography.html">Using standard bibliographies</a></li>-->
+        <!-- feature currently broken, see GitHub issue: https://github.com/Edirom/MerMEId/issues/166 -->
       </ul>
       <h3>Technical documentation</h3>
       <ul class="toc">


### PR DESCRIPTION
The feature is currently broken so commented out the link to the description page